### PR TITLE
Improve deployment docs

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -6,5 +6,6 @@
    :glob:
 
    standard-live
+   servers
 
 ```

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,0 +1,10 @@
+# Deployment
+
+```eval_rst
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   standard-live
+
+```

--- a/docs/deployment/servers.md
+++ b/docs/deployment/servers.md
@@ -1,0 +1,15 @@
+# Servers
+
+The OCDS standard website, and the OCDS validator are hosted by Open Data
+Services on VPS's provided by bytemark. Contact code [at] opendataservices
+[dot] coop with any queries that relate directly to servers.
+
+Hosting the standard:
+
+* `live2` - [standard.open-contracting.org](http://standard.open-contracting.org/) points at this server. It acts as a reverse proxy in front of `dev3` and `cove-live-ocds`, and also hosts the live docs ie. [latest](http://standard.open-contracting.org/latest/), [1.0](http://standard.open-contracting.org/1.0/), [1.1](http://standard.open-contracting.org/1.1/) and live copies of profiles e.g. [http://standard.open-contracting.org/profiles/ppp/latest/en/](http://standard.open-contracting.org/profiles/ppp/latest/en/)
+* `dev3` - hosts dev copies of the standard docs, and dev copies of profiles. Travis has sftp access to push dev builds directly to this server.
+
+Hosting the validator:
+
+* `cove-live-ocds` - live server hosts [http://standard.open-contracting.org/validator/](http://standard.open-contracting.org/validator/) behind the `live2` reverse proxy
+* `cove-dev` - hosts [http://dev.cove.opendataservices.coop/validator/](http://dev.cove.opendataservices.coop/validator/) and subdomains

--- a/docs/deployment/standard-live.md
+++ b/docs/deployment/standard-live.md
@@ -1,4 +1,4 @@
-# Deployment
+# Standard Live Deploy
 
 This section describes the steps involved in deploying an updated version of the standard to become the live version.
 

--- a/docs/deployment/standard-live.md
+++ b/docs/deployment/standard-live.md
@@ -95,6 +95,8 @@ Travis copies the built docs to the dev server, you can check they look okay the
 
 ## 8. Copy the files to the live server
 
+(See the [servers](servers) page for more info on how our servers are set up.)
+
 Each deploy has it's own unique folder on the live server (including the date
 and a sequence number). The bare version number is then symlinked. This makes
 it easy to roll back the live docs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Next steps:
    extensions
    profiles
    staging
-   deployment
+   deployment/index
    github_integrations
    tools
    resources

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -44,6 +44,8 @@ Each branch of the [public-private-partnerships](https://github.com/open-contrac
 
 ## Copying live deploy into place
 
+(See the [servers](deployment/servers) page for more info on how our servers are set up.)
+
 ```bash
 VER=1.0            # (for example)
 DATE=$(date +%F)   # or YYYY-MM-DD to match the release date on dev3

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -10,7 +10,7 @@ The PPP profile is built by patching the core OCDS schema and codelists with var
 
 To include an updated extension in the PPP profile build:
 
-1. Create a new release in Github for the version of the extension to be included in the PPP profile build (see [worked example](../deployment/index.html#to-pin-extensions-worked-example))
+1. Create a new release in Github for the version of the extension to be included in the PPP profile build (see [worked example](../deployment/standard-live/#to-pin-extensions-worked-example))
 1. Update the extension.json for the extension in the [ppp branch](https://github.com/open-contracting/extension_registry/tree/ppp) of the extension registry so that the `url` key points to the release created in step 1
 1. Run [apply-extensions.py](https://github.com/open-contracting/public-private-partnerships/blob/master/schema/apply-extensions.py)
 1. If the updated extension introduces or removes codelists from the extension, update [codelists.md](https://github.com/open-contracting/public-private-partnerships/blob/master/docs/reference/codelists.md) accordingly.
@@ -28,7 +28,7 @@ To update the base schema and codelists that the PPP extension is built on:
 
 To include a new extension in the PPP profile build:
 
-1. Create a new release in Github for the version of the extension to be included in the PPP profile build (see [worked example](./deployment.md#pinning-extensions-worked-example))
+1. Create a new release in Github for the version of the extension to be included in the PPP profile build (see [worked example](../deployment/standard-live/#pinning-extensions-worked-example))
 1. Add an entry for the extension in the [ppp branch](https://github.com/open-contracting/extension_registry/tree/ppp) of the extension registry so that the `url` key points to the release created in step 1
 1. Update the `extensions_to_merge` list in [apply-extensions.py](https://github.com/open-contracting/public-private-partnerships/blob/master/schema/apply-extensions.py) to include the slug for the extension (specified in the entry in the extension registry)
 1. Run [apply-extensions.py](https://github.com/open-contracting/public-private-partnerships/blob/master/schema/apply-extensions.py)


### PR DESCRIPTION
* Move standard live deploy information to a subpage of deployment
* Add extra deploy information to the standard live deploy page
* Add a servers page

Preview link: https://ocds-standard-development-handbook.readthedocs.io/en/deployment/deployment/