### PR TITLE
Extensions page

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -84,3 +84,11 @@ Every extension recorded in the registry must have an _entry.json_ file valid ag
 new extensions or changes to existing ones.
 
 `python compile.py` will generate two non version-controlled files (_extensions.json_ and _extension.js_) which are the reference files that OCDS needs to build the documentation on extensions.
+
+## Extension issues
+
+There is an [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) dedicated to gather issues for all extensions.
+
+You should submit issues to that repository rather than to the repositories of individual extensions. Doing so will give much more visibility to your issues and therefore a higher likelihood of getting closed soon. Also, collecting all issues in a single place helps to identify related issues across extensions.
+
+If you think you have identified a problem with extensions as a whole (e.g. there is something wrong in the way the standard deals with extensions), you may consider opening an issue in the [core standard repository](https://github.com/open-contracting/standard) pinning the _Extensions_ tag to that issue.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -19,6 +19,16 @@ All extensions must have an [extension.json](https://github.com/open-contracting
 
 Extensions must include at least one schema file. In most cases, the extension will have a _release-schema.json_ with the minimal changes required to patch the schema, although there may be more marginal user cases requiring metadata patches for _release-package-schema.json_ and/or _record-package-schema.json_. Empty schema files should not be included in the extension.
 
+Repositories for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should have issue submissions disable by default and should direct developers to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) to file issues. Best practice is to add that information to the _README.md_ file in every core extension using the following template:
+
+  > _&#35;&#35;&#35; Reporting issues_
+  > 
+  > _By default, issues are disabled for individual OCDS core extensions. Instead, there is a &#91;ocds extension repository &#93;&#40;https://github.com/open-contracting/ocds-extensions/&#41; to gather issues for all extensions in a single place._
+  > 
+  > _If you have an issue to report, please submit it there. Make sure you indicate the appropriate extension following this format in the title: &#42;&#42;&#95;extension_name: issue title&#95;&#42;&#42;._
+
+For [community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) there is no specific requirements regarding issue management.
+
 ## Naming extensions
 
 Names for extensions should conform to the following pattern:
@@ -87,8 +97,14 @@ new extensions or changes to existing ones.
 
 ## Extension issues
 
-There is an [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) dedicated to gather issues for all extensions.
+[GitHub issues](https://help.github.com/articles/about-issues/) for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should be submitted to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions), which is dedicated to gather issues for all core extensions. 
 
-You should submit issues to that repository rather than to the repositories of individual extensions. Doing so will give much more visibility to your issues and therefore a higher likelihood of getting closed soon. Also, collecting all issues in a single place helps to identify related issues across extensions.
+You should submit extension-specific issues to that repository. Collecting all issues in a single place gives much more visibility to them and therefore a higher likelihood of getting closed soon. Also, it helps to identify related issues across extensions.
 
-If you think you have identified a problem with extensions as a whole (e.g. there is something wrong in the way the standard deals with extensions), you may consider opening an issue in the [core standard repository](https://github.com/open-contracting/standard) pinning the _Extensions_ tag to that issue.
+When creating an issue, make sure you indicate the appropriate standard extension following the title format **_extension_name: issue title_**.
+
+If you think you have identified a problem with extensions as a whole (e.g. there is something wrong in the way the standard deals with extensions), you may consider opening an issue in the [core standard repository](https://github.com/open-contracting/standard) pinning the `Extensions` tag to that issue.
+
+For [community extension](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) issues refer to each extension specific documentation.
+
+

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,18 +2,88 @@
 
 ## Creating extensions
 
-### Extension template
+OCDS extensions follow the structure of the [standard extension template](https://github.com/open-contracting/standard_extension_template). The template copies the structure of the core schema (except for _versioned-release-validation-schema.json_, see below) and allows you to add or update fields in those places where the extension should modify the schema using [JSON merge patch](https://tools.ietf.org/html/rfc7396).
 
-[Extension template](https://github.com/open-contracting/standard_extension_template)
+The core repository for OCDS has 4 [schema files](https://github.com/open-contracting/standard/tree/master/standard/schema):
+
+* release-schema.json
+* release-package-schema.json
+* record-package-schema.json
+* versioned-release-validation-schema.json
+
+_versioned-release-validation-schema.json_ is produced programmaticallly (see [Make validation schema](../deployment/standard-live#make-validation-schema) in the standard deployment section), which means that you don't have to author it manually when creating an extension.
+
+**TODO**: Mechanisn for extension authors to create _versioned-release-validation-schema.json_ in their extensions.
+
+All extensions must have an [extension.json](https://github.com/open-contracting/standard_extension_template/blob/master/extension.json), with ```"name"``` and ```"description"``` fields required.
+
+Extensions must include at least one schema file. In most cases, the extension will have a _release-schema.json_ with the minimal changes required to patch the schema, although there may be more marginal user cases requiring metadata patches for _release-package-schema.json_ and/or _record-package-schema.json_. Empty schema files should not be included in the extension.
+
+
+## Naming extensions
+
+Names for extensions should conform to the following pattern:
+
+```ocds_[name]_extension```
+
+```[name]``` should be based on a JSON Pointer fragment for the name of the primary field or the primary object being added, or both if necessary. The idea is that the name should be a good indication of which part of the schema is being targeted, thus contributing to self-documenting the extension.
+
+When naming an extension, camel case (_camelCase_) should be replace with lowercase plus underscores (_camel_case_).
+
+
+## Extension descriptions
+
+Here are some guidelines for writing the text for the mandatory field ```"description"``` in _extension.json_ :
+
+* There is no maximum length for the description, but you should try to keep it concise. In any case, do not sacrifice clarity for the sake of brevity.
+* Refer to the part(s) of the schema the extension is modifying.
+* Do not include in the description the development status of the extension (e.g. _draft_). If you need to add current status, do so in a _README_ file, it will be much more visible and therefore less prone to be forgotten and not updated.
+* Avoid descriptions simply duplicating or paraphrasing the extension name:
+
+  > e.g. for _ocds_performance_failures_extension_ :
+
+  > &#x2715;  bad description: _"An extension covering performance failures in OCDS."_
+
+  > &#10003;  good description: _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_
+
+
+## Extension codelists
+
+As in the code standard repository, in the [standard extension template](https://github.com/open-contracting/standard_extension_template) there is also a [codelists folder](https://github.com/open-contracting/standard_extension_template/tree/master/codelists) to store extension-specific codelists. 
+
+Codelists are CSV files with camel case names , e.g. _contractStatus.csv_. Be aware that a codelist in your extension using the same name of an existing codelist in the standard repository will override the existing codelist.
+
+
+
+## Versioning Extensions
+
+The standard [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) are currently versioned using [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) via the [releases feature in GitHub](https://help.github.com/categories/releases/) (which builds on Git tags).
+
+This is particularly important for new releases and deployments of OCDS, as each release of the standard should point to specific versions of each extensions. For more information, see [freeze extensions](../deployment/standard-live#freeze-extensions) in the standard deployment section.
+
+[Community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions), on the other hand, are externally maintained and not pinned to releases of the standard.
+
+N.B. The mechanism for versioning extensions both 'internally' (addressing changes within the extension during the _same_ standard release cycle) and 'externally' (with reference to _different_ standard versions) is likely to change in the future. Take a look at this [GitHub issue](https://github.com/open-contracting/extension_registry/issues/47) in the [extension registry](https://github.com/open-contracting/extension_registry) repo for more information on this topic.
+
+## Tools
 
 ### Extension creator
 
-[Extension creator](https://github.com/open-contracting/extension_creator)
+The [Extension creator](https://github.com/open-contracting/extension_creator) is a GUI that allows you to modify any of the schema files and get the corresponding patch file for the extension.
+
+The tool will create a zip file to download, containing the patch schema file plus the _extension.json_ file with the name and description given by you.
+
 
 ### Extension tester
 
-[Extension tester](https://github.com/open-contracting/extension_tester)
+Another useful tool to help creating extensions is the [Extension tester](https://github.com/open-contracting/extension_tester), which provides a simple way of testing your extensions on your local machine.
 
 ## Extension registry
+The [Extensions registry](https://github.com/open-contracting/extension_registry) is the place where extensions are recorded in order to be included in the OCDS documentation.
 
-[Extensions registry](https://github.com/open-contracting/extension_registry)
+Every extension recorded in the registry must have an _entry.json_ file valid against the [entry-schema.json](https://github.com/open-contracting/extension_registry/blob/master/entry-schema.json).
+
+[compile.py](https://github.com/open-contracting/extension_registry/blob/master/compile.py) needs to be run for the docs to pick up 
+new extensions or changes to existing ones.
+
+``` python compile.py``` will generate two non version-controlled files (_extensions.json_ and _extension.js_) which are the reference files that OCDS needs to build the documentation on extensions.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -21,11 +21,15 @@ Extensions must include at least one schema file. In most cases, the extension w
 
 Repositories for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should have issue submissions disable by default and should direct developers to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) to file issues. Best practice is to add that information to the _README.md_ file in every core extension using the following template:
 
-  > _&#35;&#35;&#35; Reporting issues_
-  >
-  > _By default, issues are disabled for individual OCDS core extensions. Instead, there is a &#91;ocds extension repository &#93;&#40;https&#58;&#47;&#47;github.com/open-contracting/ocds-extensions/&#41; to gather issues for all extensions in a single place._
-  >
-  > _If you have an issue to report, please submit it there. Make sure you indicate the appropriate extension following this format in the title: &#42;&#42;&#95;extension_name: issue title&#95;&#42;&#42;._
+```none
+
+### Reporting issues
+
+By default, issues are disabled for individual OCDS core extensions. Instead, there is an [ocds extension repository](https://github.com/open-contracting/ocds-extensions) to gather issues for all extensions in a single place.
+
+If you have an issue to report, please submit it there. Make sure you indicate the appropriate extension following this format in the title: **_extension_name: issue title_**.
+
+```
 
 For [community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) there is no specific requirements regarding issue management.
 
@@ -52,7 +56,7 @@ For example, for [ocds_performance_failures_extension](https://github.com/open-c
 
   > _"An extension covering performance failures in OCDS."_
 
-Much better the actual description in the extension:
+The actual description in the extension is much better:
 
   > _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -18,9 +18,7 @@ Repositories for [core extensions](http://standard.open-contracting.org/latest/e
 
 ### Reporting issues
 
-By default, issues are disabled for individual OCDS core extensions. Instead, there is an [ocds extension repository](https://github.com/open-contracting/ocds-extensions) to gather issues for all extensions in a single place.
-
-If you have an issue to report, please submit it there. Make sure you indicate the appropriate extension following this format in the title: **_extension_name: issue title_**.
+Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -73,22 +73,13 @@ N.B. The mechanism for versioning extensions both 'internally' (addressing chang
 
 The [Extension creator](https://github.com/open-contracting/extension_creator) is a GUI that allows you to modify any of the schema files and get the corresponding patch file for the extension.
 
-The tool will create a zip file to download, containing the patch schema file plus the _extension.json_ file with the name and description given by you.
-
 ### Extension tester
 
-Another useful tool to help creating extensions is the [Extension tester](https://github.com/open-contracting/extension_tester), which provides a simple way of testing your extensions on your local machine.
+The [Extension tester](https://github.com/open-contracting/extension_tester) provides a simple way to test your extensions on your local machine.
 
 ## Extension registry
 
 The [Extensions registry](https://github.com/open-contracting/extension_registry) is the place where extensions are recorded in order to be included in the OCDS documentation.
-
-Every extension recorded in the registry must have an _entry.json_ file valid against the [entry-schema.json](https://github.com/open-contracting/extension_registry/blob/master/entry-schema.json).
-
-[compile.py](https://github.com/open-contracting/extension_registry/blob/master/compile.py) needs to be run for the docs to pick up
-new extensions or changes to existing ones.
-
-`python compile.py` will generate two non version-controlled files (_extensions.json_ and _extension.js_) which are the reference files that OCDS needs to build the documentation on extensions.
 
 ## Extension issues
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,44 +15,42 @@ _versioned-release-validation-schema.json_ is produced programmaticallly (see [M
 
 **TODO**: Mechanisn for extension authors to create _versioned-release-validation-schema.json_ in their extensions.
 
-All extensions must have an [extension.json](https://github.com/open-contracting/standard_extension_template/blob/master/extension.json), with ```"name"``` and ```"description"``` fields required.
+All extensions must have an [extension.json](https://github.com/open-contracting/standard_extension_template/blob/master/extension.json), with `"name"` and `"description"` fields required.
 
 Extensions must include at least one schema file. In most cases, the extension will have a _release-schema.json_ with the minimal changes required to patch the schema, although there may be more marginal user cases requiring metadata patches for _release-package-schema.json_ and/or _record-package-schema.json_. Empty schema files should not be included in the extension.
-
 
 ## Naming extensions
 
 Names for extensions should conform to the following pattern:
 
-```ocds_[name]_extension```
+`ocds_[name]_extension`
 
-```[name]``` should be based on a JSON Pointer fragment for the name of the primary field or the primary object being added, or both if necessary. The idea is that the name should be a good indication of which part of the schema is being targeted, thus contributing to self-documenting the extension.
+`[name]` should be based on a JSON Pointer fragment for the name of the primary field or the primary object being added, or both if necessary. The idea is that the name should be a good indication of which part of the schema is being targeted, thus contributing to self-documenting the extension.
 
 When naming an extension, camel case (_camelCase_) should be replace with lowercase plus underscores (_camel_case_).
 
-
 ## Extension descriptions
 
-Here are some guidelines for writing the text for the mandatory field ```"description"``` in _extension.json_ :
+Here are some guidelines for writing the text for the mandatory field `"description"` in _extension.json_ :
 
 * There is no maximum length for the description, but you should try to keep it concise. In any case, do not sacrifice clarity for the sake of brevity.
 * Refer to the part(s) of the schema the extension is modifying.
 * Do not include in the description the development status of the extension (e.g. _draft_). If you need to add current status, do so in a _README_ file, it will be much more visible and therefore less prone to be forgotten and not updated.
-* Avoid descriptions simply duplicating or paraphrasing the extension name:
+* Avoid descriptions that simply duplicate or paraphrase the extension name.
 
-  > e.g. for _ocds_performance_failures_extension_ :
-
-  > &#x2715;  bad description: _"An extension covering performance failures in OCDS."_
-
-  > &#10003;  good description: _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_
-
+  > e.g. for _ocds_performance_failures_extension_, this is not a good description:
+  >
+  > _"An extension covering performance failures in OCDS."_ &#x2715;
+  >
+  > This one is much better:
+  >
+  > _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_ &#10003;
 
 ## Extension codelists
 
-As in the code standard repository, in the [standard extension template](https://github.com/open-contracting/standard_extension_template) there is also a [codelists folder](https://github.com/open-contracting/standard_extension_template/tree/master/codelists) to store extension-specific codelists. 
+As in the code standard repository, in the [standard extension template](https://github.com/open-contracting/standard_extension_template) there is also a [codelists folder](https://github.com/open-contracting/standard_extension_template/tree/master/codelists) to store extension-specific codelists.
 
 Codelists are CSV files with camel case names , e.g. _contractStatus.csv_. Be aware that a codelist in your extension using the same name of an existing codelist in the standard repository will override the existing codelist.
-
 
 ## Versioning Extensions
 
@@ -64,7 +62,6 @@ This is particularly important for new releases and deployments of OCDS, as each
 
 N.B. The mechanism for versioning extensions both 'internally' (addressing changes within the extension during the _same_ standard release cycle) and 'externally' (with reference to _different_ standard versions) is likely to change in the future. Take a look at this [GitHub issue](https://github.com/open-contracting/extension_registry/issues/47) in the [extension registry](https://github.com/open-contracting/extension_registry) repo for more information on this topic.
 
-
 ## Tools
 
 ### Extension creator
@@ -73,18 +70,17 @@ The [Extension creator](https://github.com/open-contracting/extension_creator) i
 
 The tool will create a zip file to download, containing the patch schema file plus the _extension.json_ file with the name and description given by you.
 
-
 ### Extension tester
 
 Another useful tool to help creating extensions is the [Extension tester](https://github.com/open-contracting/extension_tester), which provides a simple way of testing your extensions on your local machine.
 
-
 ## Extension registry
+
 The [Extensions registry](https://github.com/open-contracting/extension_registry) is the place where extensions are recorded in order to be included in the OCDS documentation.
 
 Every extension recorded in the registry must have an _entry.json_ file valid against the [entry-schema.json](https://github.com/open-contracting/extension_registry/blob/master/entry-schema.json).
 
-[compile.py](https://github.com/open-contracting/extension_registry/blob/master/compile.py) needs to be run for the docs to pick up 
+[compile.py](https://github.com/open-contracting/extension_registry/blob/master/compile.py) needs to be run for the docs to pick up
 new extensions or changes to existing ones.
 
-``` python compile.py``` will generate two non version-controlled files (_extensions.json_ and _extension.js_) which are the reference files that OCDS needs to build the documentation on extensions.
+`python compile.py` will generate two non version-controlled files (_extensions.json_ and _extension.js_) which are the reference files that OCDS needs to build the documentation on extensions.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -48,13 +48,13 @@ Here are some guidelines for writing the text for the mandatory field `"descript
 * Do not include in the description the development status of the extension (e.g. _draft_). If you need to add current status, do so in a _README_ file, it will be much more visible and therefore less prone to be forgotten and not updated.
 * Avoid descriptions that simply duplicate or paraphrase the extension name.
 
-  > e.g. for _ocds_performance_failures_extension_, this is not a good description:
-  >
-  > _"An extension covering performance failures in OCDS."_ &#x2715;
-  >
-  > This one is much better:
-  >
-  > _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_ &#10003;
+For example, for [ocds_performance_failures_extension](https://github.com/open-contracting/ocds_performance_failures) , this wouldn't be a good description:
+
+  > _"An extension covering performance failures in OCDS."_
+
+Much better the actual description in the extension:
+
+  > _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_
 
 ## Extension codelists
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -22,9 +22,9 @@ Extensions must include at least one schema file. In most cases, the extension w
 Repositories for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should have issue submissions disable by default and should direct developers to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) to file issues. Best practice is to add that information to the _README.md_ file in every core extension using the following template:
 
   > _&#35;&#35;&#35; Reporting issues_
-  > 
-  > _By default, issues are disabled for individual OCDS core extensions. Instead, there is a &#91;ocds extension repository &#93;&#40;https://github.com/open-contracting/ocds-extensions/&#41; to gather issues for all extensions in a single place._
-  > 
+  >
+  > _By default, issues are disabled for individual OCDS core extensions. Instead, there is a &#91;ocds extension repository &#93;&#40;https&#58;&#47;&#47;github.com/open-contracting/ocds-extensions/&#41; to gather issues for all extensions in a single place._
+  >
   > _If you have an issue to report, please submit it there. Make sure you indicate the appropriate extension following this format in the title: &#42;&#42;&#95;extension_name: issue title&#95;&#42;&#42;._
 
 For [community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) there is no specific requirements regarding issue management.
@@ -97,7 +97,7 @@ new extensions or changes to existing ones.
 
 ## Extension issues
 
-[GitHub issues](https://help.github.com/articles/about-issues/) for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should be submitted to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions), which is dedicated to gather issues for all core extensions. 
+[GitHub issues](https://help.github.com/articles/about-issues/) for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should be submitted to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions), which is dedicated to gather issues for all core extensions.
 
 You should submit extension-specific issues to that repository. Collecting all issues in a single place gives much more visibility to them and therefore a higher likelihood of getting closed soon. Also, it helps to identify related issues across extensions.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,13 +2,7 @@
 
 ## Creating extensions
 
-To create a new extension, you should use the [standard extension template](https://github.com/open-contracting/standard_extension_template), which following the core OCDS schema includes the following files:
-
-* release-schema.json
-* release-package-schema.json
-* record-package-schema.json
-
-Extensions must include at least one schema file. In most cases, the extension will have a _release-schema.json_ with the minimal changes required to patch the schema, although there may be more marginal user cases requiring metadata patches for _release-package-schema.json_ and/or _record-package-schema.json_. Empty schema files should not be included in the extension.
+To create a new extension, it is recommended to use the [standard extension template](https://github.com/open-contracting/standard_extension_template).
 
 Under the hood, OCDS extensions use JSON merge patch to apply changes to the target schema. To know more, see [JSON merge patch documentation](https://tools.ietf.org/html/rfc7396).
 
@@ -59,5 +53,3 @@ When creating an issue, make sure you indicate the appropriate standard extensio
 If you think you have identified a problem with extensions as a whole (e.g. there is something wrong in the way the standard deals with extensions), you may consider opening an issue in the [core standard repository](https://github.com/open-contracting/standard) pinning the `Extensions` tag to that issue.
 
 For [community extension](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) issues refer to each extension specific documentation.
-
-

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -54,7 +54,6 @@ As in the code standard repository, in the [standard extension template](https:/
 Codelists are CSV files with camel case names , e.g. _contractStatus.csv_. Be aware that a codelist in your extension using the same name of an existing codelist in the standard repository will override the existing codelist.
 
 
-
 ## Versioning Extensions
 
 The standard [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) are currently versioned using [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) via the [releases feature in GitHub](https://help.github.com/categories/releases/) (which builds on Git tags).
@@ -64,6 +63,7 @@ This is particularly important for new releases and deployments of OCDS, as each
 [Community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions), on the other hand, are externally maintained and not pinned to releases of the standard.
 
 N.B. The mechanism for versioning extensions both 'internally' (addressing changes within the extension during the _same_ standard release cycle) and 'externally' (with reference to _different_ standard versions) is likely to change in the future. Take a look at this [GitHub issue](https://github.com/open-contracting/extension_registry/issues/47) in the [extension registry](https://github.com/open-contracting/extension_registry) repo for more information on this topic.
+
 
 ## Tools
 
@@ -77,6 +77,7 @@ The tool will create a zip file to download, containing the patch schema file pl
 ### Extension tester
 
 Another useful tool to help creating extensions is the [Extension tester](https://github.com/open-contracting/extension_tester), which provides a simple way of testing your extensions on your local machine.
+
 
 ## Extension registry
 The [Extensions registry](https://github.com/open-contracting/extension_registry) is the place where extensions are recorded in order to be included in the OCDS documentation.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,22 +2,15 @@
 
 ## Creating extensions
 
-OCDS extensions follow the structure of the [standard extension template](https://github.com/open-contracting/standard_extension_template). The template copies the structure of the core schema (except for _versioned-release-validation-schema.json_, see below) and allows you to add or update fields in those places where the extension should modify the schema using [JSON merge patch](https://tools.ietf.org/html/rfc7396).
-
-The core repository for OCDS has 4 [schema files](https://github.com/open-contracting/standard/tree/master/standard/schema):
+To create a new extension, you should use the [standard extension template](https://github.com/open-contracting/standard_extension_template), which following the [core OCDS schema](https://github.com/open-contracting/standard/tree/master/standard/schema) includes the following files:
 
 * release-schema.json
 * release-package-schema.json
 * record-package-schema.json
-* versioned-release-validation-schema.json
-
-_versioned-release-validation-schema.json_ is produced programmaticallly (see [Make validation schema](../deployment/standard-live#make-validation-schema) in the standard deployment section), which means that you don't have to author it manually when creating an extension.
-
-**TODO**: Mechanisn for extension authors to create _versioned-release-validation-schema.json_ in their extensions.
-
-All extensions must have an [extension.json](https://github.com/open-contracting/standard_extension_template/blob/master/extension.json), with `"name"` and `"description"` fields required.
 
 Extensions must include at least one schema file. In most cases, the extension will have a _release-schema.json_ with the minimal changes required to patch the schema, although there may be more marginal user cases requiring metadata patches for _release-package-schema.json_ and/or _record-package-schema.json_. Empty schema files should not be included in the extension.
+
+Under the hood, OCDS extensions use JSON merge patch to apply changes to the target schema. To know more, see [JSON merge patch documentation](https://tools.ietf.org/html/rfc7396).
 
 Repositories for [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) should have issue submissions disable by default and should direct developers to the [OCDS extension issues repository](https://github.com/open-contracting/ocds-extensions) to file issues. Best practice is to add that information to the _README.md_ file in every core extension using the following template:
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,7 +2,7 @@
 
 ## Creating extensions
 
-To create a new extension, you should use the [standard extension template](https://github.com/open-contracting/standard_extension_template), which following the [core OCDS schema](https://github.com/open-contracting/standard/tree/master/standard/schema) includes the following files:
+To create a new extension, you should use the [standard extension template](https://github.com/open-contracting/standard_extension_template), which following the core OCDS schema includes the following files:
 
 * release-schema.json
 * release-package-schema.json
@@ -23,39 +23,6 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 ```
 
 For [community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions) there is no specific requirements regarding issue management.
-
-## Naming extensions
-
-Names for extensions should conform to the following pattern:
-
-`ocds_[name]_extension`
-
-`[name]` should be based on a JSON Pointer fragment for the name of the primary field or the primary object being added, or both if necessary. The idea is that the name should be a good indication of which part of the schema is being targeted, thus contributing to self-documenting the extension.
-
-When naming an extension, camel case (_camelCase_) should be replace with lowercase plus underscores (_camel_case_).
-
-## Extension descriptions
-
-Here are some guidelines for writing the text for the mandatory field `"description"` in _extension.json_ :
-
-* There is no maximum length for the description, but you should try to keep it concise. In any case, do not sacrifice clarity for the sake of brevity.
-* Refer to the part(s) of the schema the extension is modifying.
-* Do not include in the description the development status of the extension (e.g. _draft_). If you need to add current status, do so in a _README_ file, it will be much more visible and therefore less prone to be forgotten and not updated.
-* Avoid descriptions that simply duplicate or paraphrase the extension name.
-
-For example, for [ocds_performance_failures_extension](https://github.com/open-contracting/ocds_performance_failures) , this wouldn't be a good description:
-
-  > _"An extension covering performance failures in OCDS."_
-
-The actual description in the extension is much better:
-
-  > _"This extension introduces a performance failures array to the implementation section of OCDS, based on the performance failures reporting table defined in the framework for disclosure in PPPs."_
-
-## Extension codelists
-
-As in the code standard repository, in the [standard extension template](https://github.com/open-contracting/standard_extension_template) there is also a [codelists folder](https://github.com/open-contracting/standard_extension_template/tree/master/codelists) to store extension-specific codelists.
-
-Codelists are CSV files with camel case names , e.g. _contractStatus.csv_. Be aware that a codelist in your extension using the same name of an existing codelist in the standard repository will override the existing codelist.
 
 ## Versioning Extensions
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,7 +15,7 @@ To include an updated extension in the PPP profile build:
 1. Run [apply-extensions.py](https://github.com/open-contracting/public-private-partnerships/blob/master/schema/apply-extensions.py)
 1. If the updated extension introduces or removes codelists from the extension, update [codelists.md](https://github.com/open-contracting/public-private-partnerships/blob/master/docs/reference/codelists.md) accordingly.
 
-### Updating the base schema and codeliste
+### Updating the base schema and codelist
 
 To update the base schema and codelists that the PPP extension is built on:
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -20,14 +20,6 @@
 
 ## Extension tools
 
-### Extension template
+References to existing tools for extensions can be found in the [Extension page tool section](../extensions#tools) of this handbook.
 
-[Extension template](https://github.com/open-contracting/standard_extension_template)
-
-### Extension creator
-
-[Extension creator](https://github.com/open-contracting/extension_creator)
-
-### Extension tester
-
-[Extension tester](https://github.com/open-contracting/extension_tester)
+For general guidance on using the [standard extension template](https://github.com/open-contracting/standard_extension_template), see [creating extensions](../extensions#creating-extensions).


### PR DESCRIPTION
This PR addresses documentation related to a number of extension issues:
#15  - The guidance for describing extensions is <del>in the handbook</del> in a [PR](https://github.com/open-contracting/standard_extension_template/pull/9) in the extension template repo, but if we merge that we also need to comply with it by changing the non-conforming descriptions.
#16  - As for #15  , but for extension names.
<del>#19 - The handbook explains that  `versioned-release-validation-schema.json` is generated programmatically for the standard and should be the same for extensions, however we still need to come with a mechanism in place to do so.  Also, further actions as described in the issue need to be taken to make the documentation true.</del>
#23 - Reference to the repo for extension issues https://github.com/open-contracting/ocds-extensions  has been added to the handbook. Outstanding action for this issue: add a standard content block to READMEs in extensions.

@jpmckinney let me know if you'd like me to go ahead and address outstanding actions for those issues.
