### PR TITLE
Add admonitions for which steps can be skipped

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -31,7 +31,7 @@ Once an extension is created, it should be added to the [extension_registry](htt
 
 The [*core* extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions) are versioned using [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) and made available as [releases on GitHub](https://help.github.com/categories/releases/) (which depend on tags).
 
-This is particularly important for new versions of the standard, as each version's documentation should point to specific versions of its extensions. For more information, see [freezing extensions](../standard/technical/deployment#freeze-extensions).
+This is particularly important for new versions of the standard, as each version's documentation should point to specific versions of its extensions. For more information, see [pinning extensions](../standard/technical/deployment#pin-extensions).
 
 [Community extensions](http://standard.open-contracting.org/latest/en/extensions/#community-extensions), on the other hand, are externally maintained and not associated to each version of the standard.
 

--- a/docs/github/tags_and_releases.md
+++ b/docs/github/tags_and_releases.md
@@ -1,5 +1,5 @@
 # Tags and releases
 
-Core extensions use tags and releases as documented under [freezing extensions](../standard/technical/deployment#freeze-extensions).
+Core extensions use tags and releases as documented under [pinning extensions](../standard/technical/deployment#pin-extensions).
 
 The [`standard` repository](https://github.com/open-contracting/standard) uses tags and releases as documented under [branches and tags](../standard/technical/repository#branches-and-tags) and [creating a tagged release](../standard/technical/deployment#create-a-tagged-release).

--- a/docs/standard/technical/deployment.md
+++ b/docs/standard/technical/deployment.md
@@ -8,38 +8,42 @@ For changes to documentation only (no schema changes), start from step 4.
 
 For changes to the theme only, start from step 7.
 
-## 1. Freeze extensions
+## 1. Pin extensions
 
-Each release of the standard should pin to specific versions of each extension in [core extensions](http://standard.open-contracting.org/latest/en/extensions/#core-extensions). Community extensions are not pinned.
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
 
-This is currently achieved by:
+Each release of the standard should pin to specific versions of each [core extension](http://standard.open-contracting.org/latest/en/extensions/#core-extensions). Community extensions are not pinned. The steps are:
 
-* Creating a tagged release of each extension
-* Creating a tagged release of the extension registry that points to these specific versions
-* Pulling extensions' Markdown files
-* Setting the documentation build process to refer to the relevant extension registry tag
+1. Review open pull requests and changes since last release of core extensions
+1. Create new releases of core extensions
+1. Create a new release of the extension registry to point to the new releases of extensions
+1. Pull extensions' Markdown files into the standard
+1. Set the documentation build process to use the new extension registry tag
 
-### Pinning extensions: worked example
+### Review open pull requests and changes since last release of core extensions
 
-For each **core extension**:
+For each *core* extension:
 
-#### Review outstanding pull requests and changes since last release
-
-1. Open the relevant repository in the GitHub web interface ([example](https://github.com/open-contracting/ocds_lots_extension))
-1. Review any outstanding [pull requests](https://github.com/open-contracting/ocds_lots_extension/pulls) and discuss these to determine whether they should be merged before pinning the extension
-1. Under the repository title and description, click **Releases** to view the list of existing releases ([example](https://github.com/open-contracting/ocds_lots_extension/releases))
-1. Under the title of the most recent release, the number of commits since that release will be listed, if there are no commits since the last release then skip to 'Publish a new release', otherwise click the link to view the list of changes since the last release ([example](https://github.com/open-contracting/ocds_lots_extension/compare/v1.1...master))
-1. Check the list of changes since the last release against the [changelog](http://standard.open-contracting.org/latest/en/schema/changelog/#changelog) for the version of OCDS being deployed
+1. Open the extension's [homepage](https://github.com/open-contracting/ocds_lots_extension) on GitHub
+1. Review [open pull requests](https://github.com/open-contracting/ocds_lots_extension/pulls) and discuss whether to merge any
+1. Open the extension's [releases](https://github.com/open-contracting/ocds_lots_extension/releases) (under the repository title and description from the extension's homepage)
+1. Click to view the [commits since the last release](https://github.com/open-contracting/ocds_lots_extension/compare/v1.1...master) (under the release's heading). If there are no new commits, skip the rest of this step.
+1. Check the changes against the [changelog](http://standard.open-contracting.org/latest/en/schema/changelog/#changelog) for the version of OCDS being deployed
 1. Before publishing the release, discuss any substantive changes, i.e. not simple typo or documentation updates, which aren't included in the changelog
 
-#### Publish a new release
+### Create new releases of core extensions
 
-1. From the list of releases, click **Draft a new release**
-1. In the 'Tag version' field, enter the version of OCDS being deployed in _vmajor.minor.patch_ format, e.g. `v1.1.1`
-1. In the 'Release title' field, enter a title, e.g. 'Fixed version for OCDS 1.1.1'
-1. Enter a brief summary of changes, e.g. 'Typo fixes', and click **Publish release**
+For each *core* extension:
 
-### Pulling extension documentation
+1. From the list of releases, click *Draft a new release*
+1. In the *Tag version* field, enter the version of OCDS being deployed in *vmajor.minor.patch* format, e.g. `v1.1.1`
+1. In the *Release title* field, enter a title, e.g. "Fixed version for OCDS 1.1.1"
+1. Enter a brief summary of changes, e.g. "Typo fixes", and click *Publish release*
+
+### Pull extensions' Markdown files into the standard
 
 ```bash
 cd standard/docs/en/extensions
@@ -47,13 +51,18 @@ cd standard/docs/en/extensions
 ./get-readmes.py
 ```
 
-### Setting documentation build extension registry tag
+### Set the documentation build process to use the new extension registry tag
 
 Edit `standard/docs/en/conf.py` and set `extension_registry_git_ref` to e.g. `v1.1.1`.
 
 ## 2. Check schema IDs
 
-Check that the `id` property at the top of each JSON schema file have been updated to reflect the current major__minor__patch version number.
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
+
+Check that the `id` property at the top of each JSON schema file have been updated to reflect the current *major__minor__patch* version number.
 
 For example:
 
@@ -64,24 +73,26 @@ For example:
 }
 ```
 
-## 3. Make validation schema
+## 3. Make the validation schema
+
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
 
 The _versioned-release-validation-schema.json_ file exists for validation of versioned releases. It is currently programatically generated from the latest version of the schema and committed to the repository.
 
 To run this script:
 
-1. Update `standard/schema/make_validation_schema.py` to refer to the correct version number (Line 94)
+1. Update `standard/schema/make_validation_schema.py` to refer to the correct version number (line 94).
 1. Run `make_validation_schema.py`
-
-Then commit the updated _versioned-release-validation-schema.json_ file to the repository.
+1. commit the updated _versioned-release-validation-schema.json_ file to the repository.
 
 ## 4. Push and pull updated translations
 
-Run `tx push -s` to push updated sources files to Transifex.
-
-Run `tx pull -a -f` to pull all updated translation files down locally.
-
-Commit the updated translations to the repository.
+1. Run `tx push -s` to push updated source files to Transifex.
+1. Run `tx pull -a -f` to pull updated translation files to the repository.
+1. Commit the updated translation files to the repository.
 
 ```eval_rst
   .. todo::
@@ -94,7 +105,12 @@ The dev working branch should be merged into the relevant live branch, e.g. merg
 
 ## 6. Create a tagged release
 
-(Major/Minor/Patch versions only) Create a tagged release named e.g. `1__1__0`
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
+
+Create a tagged release named e.g. `1__1__0`
 
 ## 7. Build on Travis
 
@@ -145,7 +161,13 @@ If a new language is supported, edit `http://standard.open-contracting.org/robot
 
 ## 9. Copy the schema into place
 
-(Major/Minor/Patch versions only) Copy the JSON from the schema directory of the build to `/home/ocds-docs/web/schema/[release_tag]` on the live server, e.g. for 1.1.1:
+
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
+
+Copy the JSON from the schema directory of the build to `/home/ocds-docs/web/schema/[release_tag]` on the live server, e.g. for 1.1.1:
 
 ```bash
 ssh root@live2.default.opendataservices.uk0.bigv.io
@@ -157,13 +179,19 @@ The JSON files are then visible at [http://standard.open-contracting.org/schema/
 
 ## 10. Update the "latest" branch
 
-If the build should also appear at [/latest/](http://standard.open-contracting.org/latest/), then update the `latest` branch on GitHub to point to the same commit. Wait for the travis build, then repeat step 8 with `VER=latest`.
+If the build should also appear at [/latest/](http://standard.open-contracting.org/latest/), then update the `latest` branch on GitHub to point to the same commit. Wait for the Travis build, then repeat step 8 with `VER=latest`.
 
 Doing a build is necessary because some URLs are updated with the branch name (e.g. links in the schema).
 
 ## 11. Update the Apache config
 
-(Major/Minor versions only) For a new live version, you will need to edit:
+
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
+
+For a new live version, you will need to edit:
 
 * [live_versions in the Apache config](https://github.com/OpenDataServices/opendataservices-deploy/blob/master/salt/apache/ocds-docs-live.conf#L16)
 * [version switcher](https://github.com/OpenDataServices/opendataservices-deploy/blob/master/salt/ocds-docs/includes/version-options.html)
@@ -171,7 +199,10 @@ Doing a build is necessary because some URLs are updated with the branch name (e
 
 ## 12. Update the OCDS validator
 
-(Major/Minor versions only)
+```eval_rst
+  .. note::
+    You can skip this step if you are not releasing a new major, minor or patch version.
+```
 
 * Set up a development instance of CoVE using the new schema, and run tests against it
 * Update the live CoVE deployment to use the new schema

--- a/docs/standard/technical/deployment.md
+++ b/docs/standard/technical/deployment.md
@@ -161,7 +161,6 @@ If a new language is supported, edit `http://standard.open-contracting.org/robot
 
 ## 9. Copy the schema into place
 
-
 ```eval_rst
   .. note::
     You can skip this step if you are not releasing a new major, minor or patch version.
@@ -184,7 +183,6 @@ If the build should also appear at [/latest/](http://standard.open-contracting.o
 Doing a build is necessary because some URLs are updated with the branch name (e.g. links in the schema).
 
 ## 11. Update the Apache config
-
 
 ```eval_rst
   .. note::

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,13 +1,13 @@
 # Tools and resources
 
-* The [OCDS validator](http://standard.open-contracting.org/validator/) is a deployment of [CoVE (GitHub)](https://github.com/OpenDataServices/cove) to convert between spreadsheet and JSON representations of OCDS data, and to validate against the standard. 
-* [mapping-sheet-generator](https://github.com/open-contracting/mapping-sheet-generator) generates a flattened representation of an OCDS schema. 
-* [ocds-faker](https://github.com/open-contracting/ocds-faker) is a command-line tool to generate clearly fake data for OCDS release packages, for testing. 
-* [ocds-merge](https://github.com/open-contracting/ocds-merge) is a Python library that provides functions to merge a list of OCDS releases into a `compiledRelease` or a `versionedRelease`, for creating an OCDS record. 
-* [ocds-show](https://github.com/open-contracting/ocds-show) is a JavaScript application to visualize OCDS releases and records, to allow easier comprehension of OCDS data. 
+* The [OCDS validator](http://standard.open-contracting.org/validator/) is a deployment of [CoVE (GitHub)](https://github.com/OpenDataServices/cove) to convert between spreadsheet and JSON representations of OCDS data, and to validate against the standard.
+* [mapping-sheet-generator](https://github.com/open-contracting/mapping-sheet-generator) generates a flattened representation of an OCDS schema.
+* [ocds-faker](https://github.com/open-contracting/ocds-faker) is a command-line tool to generate clearly fake data for OCDS release packages, for testing.
+* [ocds-merge](https://github.com/open-contracting/ocds-merge) is a Python library that provides functions to merge a list of OCDS releases into a `compiledRelease` or a `versionedRelease`, for creating an OCDS record.
+* [ocds-show](https://github.com/open-contracting/ocds-show) is a JavaScript application to visualize OCDS releases and records, to allow easier comprehension of OCDS data.
 * [ocds-show-ppp](https://github.com/open-contracting/ocds-show-ppp) is an instance of OCDS Show configured for the [PPP profile](http://standard.open-contracting.org/profiles/ppp/latest/en/) of OCDS.
 * [ocds-tabulate](https://github.com/open-contracting/ocds-tabulate) is a Python script to convert OCDS data into tabular form, for importing into a relational database.
-* [sample-data](https://github.com/open-contracting/sample-data) contains a selection of sample data that can help demonstrate what OCDS data looks like. 
+* [sample-data](https://github.com/open-contracting/sample-data) contains a selection of sample data that can help demonstrate what OCDS data looks like.
 
 For tools relating to extensions, see [extensions tools](../extensions#tools). For guidance on using the [standard extension template](https://github.com/open-contracting/standard_extension_template) in particular, see [creating extensions](../extensions#creating-extensions).
 


### PR DESCRIPTION
…when deploying an update to the same version of the standard.

I made some copy-edits, but I'd like others to confirm whether the `note::` admonitions are true.