### PR TITLE
Updating extension and schema authorship guidance

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1,5 +1,15 @@
 # Extensions
 
+An OCDS release or record package may declare one or more extensions. Extensions can add to the schema, add new codelists, or add entries to existing codelists. 
+
+* **Core extensions** are maintained as part of the standard governance process.
+* A directory of **community extensions** is maintained to allow users to discover common properties and data models they may wish to use for additional data;
+* Publishers may declare their own **local extensions** to suppress validation warnings about additional fields or codelist values in their data, and to document additional fields in their data. 
+
+In addition, a collection of extensions may be packaged together as an **OCDS profile**. When used as part of a profile, extensions may additionally: remove scheme elements and codelist entries. 
+
+The structure of an extension is documented via the [standard extension template](https://github.com/open-contracting/standard_extension_template/blob/master/README.md).
+
 ## When to create a *core* extension
 
 * An extension can be authored to limit 'scope creep' of the core standard, especially in cases where we lack implementation experience with the proposed changes. The extension may serve as a way to externalize the risk of permanent changes to the core standard.

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -2,9 +2,7 @@
 
 An OCDS release or record package may declare one or more extensions. Extensions can add to the schema, add new codelists, or add entries to existing codelists. 
 
-* **Core extensions** are maintained as part of the standard governance process.
-* A directory of **community extensions** is maintained to allow users to discover common properties and data models they may wish to use for additional data;
-* Publishers may declare their own **local extensions** to suppress validation warnings about additional fields or codelist values in their data, and to document additional fields in their data. 
+See the [standard documentation](http://standard.open-contracting.org/latest/en/extensions/) for definitions of core, community and local extensions.
 
 In addition, a collection of extensions may be packaged together as an **OCDS profile**. When used as part of a profile, extensions may additionally: remove scheme elements and codelist entries. 
 

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -28,6 +28,12 @@ Use American English (e.g. 'organization' rather than 'organisation') unless we 
 
 ## Schema style guide
 
+
+* We use lower [camelCase](https://en.wikipedia.org/wiki/Camel_case) for property names. e.g. `awardCriteriaDetails`.
+* We use upper [CamelCase](https://en.wikipedia.org/wiki/Camel_case) for objects directly nested within the `definitions` section. e.g. `Award`.
+* We put the qualifier *before* the concept. e.g. `enquiryPeriod` rather than `periodOfEnquiry`.
+* We use singular for properties pointing to an object or literal value.
+* We use plural for properties pointing to an array of values. 
 * Property and object names should not include the name of the parent object, e.g. `title` not `tenderTitle`, `description` not `awardDescription`, etc.
 * Date fields should use the `"format": "date-time"` key to enforce use of ISO8601
 * The `period` object should be used in place of `year` or `month` fields

--- a/docs/standard/conventions.md
+++ b/docs/standard/conventions.md
@@ -1,0 +1,87 @@
+# Schema conventions
+
+This page documents conventions that MUST or SHOULD be applied when authoring OCDS schema or extensions.
+
+## Definitions section
+
+The top level of the schema is split between `properties` (the basic structure of an OCDS release) and `definitions` (containing objects that may be re-used in multiple locations across the schema) which are referenced whenever they are used. 
+
+Each of the objects in `definitions` can be thought of as a 'Class', and it's name is capitalised accordingly. 
+ 
+Whenever you consider that an object or structure might be re-used in a different area of the standard, it should be included in `definitions`, and referenced. 
+
+## Naming conventions
+
+We use lower [camelCase](https://en.wikipedia.org/wiki/Camel_case) for property names. E.g. `awardCriteriaDetails`.
+
+We use upper [CamelCase](https://en.wikipedia.org/wiki/Camel_case) for objects directly nested within in the `definitions` section. E.g. `Award`.
+
+We put the qualifier *before* the concept. E.g. `enquiryPeriod` rather than `periodOfEnquiry`.
+
+We use singular for properties pointing to an object or literal value.
+
+We use plural for properties pointing to an array of values. 
+
+
+## ID fields
+
+Any object that is contained within an array MUST have an `id` field. 
+
+This is because:
+
+* `id` values play a [special role in the flatten-tool](http://flatten-tool.readthedocs.io/en/latest/unflatten/#relationships-using-identifiers) used to round-trip between JSON and tabular representations of OCDS;
+* `id` values are used to determine [how lists of objects are merged](http://standard.open-contracting.org/latest/en/schema/merging/#identifier-merge) when creating a compiledRelease. 
+
+Objects that are not contained within an array MAY include an `id` property in order to support cross-referencing, or whether the `id` relates to an identifier of the object in the real world. 
+
+## Types and null
+
+Any non-required property pointing to a literal, array of literals, or single object should support a type of `null`. E.g.:
+
+```json
+{ 
+  "status": {
+        "title": "Contract status",
+        "type": [
+            "string",
+            "null"
+          ]
+        }
+}
+```
+
+Allowing properties to be `null` is important to the [merging process](http://standard.open-contracting.org/latest/en/schema/merging/), in which `null` is used to [remove a value from the compiledRelease](http://standard.open-contracting.org/latest/en/schema/reference/#emptying-fields-and-values).
+
+(To be confirmed:) Any non-required property pointing to an array of objects should not allow `null` as a value, as array entries should be explicitly tagged for removal following the pattern outlined in [Standard#232](https://github.com/open-contracting/standard/issues/232) 
+
+```eval_rst
+  .. todo::
+    Confirm the guidance on null above. :issue:`75`
+```
+
+## Detail fields
+
+We have adopted a common pattern in OCDS of pairing a codelist, with a `Details` field which can be used for either:
+
+* Free text details on the codelist value;
+* A more detailed set of classifications from a publisher's systems;
+
+For example, a country may have five procurement procedures: A, B, C, D and E. 
+
+The `procurementMethod` field uses a closed codelist ('open','selective','limited','direct') to which these five procedures should be mapped. The `procurementMethodDetails` field then exists, into which they can input their original, unmapped classifications: A, B, C, D or E. 
+
+Use of `Detail` fields can help increase acceptance of a closed codelist.
+
+## Additional array
+
+The `additionalX` pattern is used when:
+
+* A data owner might have one or more values for a property;
+* One of those values can be considered in some way 'primary';
+* A number of use-cases can be met by looking only at the primary value.
+
+For example, a source system may record the company registration number and VAT identifier of a company. If we had a single `parties.identifier` object, the data owner would have to pick which identifier to use, and would be omitting data that could help some users to identify an organisation. If we only had an array of `parties.identifiers`, then the data structure for the simple case (only one identifier) becomes more complex, and it is not possible to indicate any priority between the identifiers. 
+
+Using the `additionalX` pattern we have a property (e.g. `property`) referencing an object, paired with an `additionalProperties` property that points to an array of the same object. 
+
+

--- a/docs/standard/conventions.md
+++ b/docs/standard/conventions.md
@@ -4,24 +4,15 @@ This page documents conventions that MUST or SHOULD be applied when authoring OC
 
 ## Definitions section
 
-The top level of the schema is split between `properties` (the basic structure of an OCDS release) and `definitions` (containing objects that may be re-used in multiple locations across the schema) which are referenced whenever they are used. 
+The top level of the schema is split between `properties` and `definitions` (containing objects that may be re-used in multiple locations across the schema) which are referenced whenever they are used. 
 
-Each of the objects in `definitions` can be thought of as a 'Class', and it's name is capitalised accordingly. 
+Each of the objects in `definitions` can be thought of as a 'Class', and its name is capitalized accordingly. 
  
 Whenever you consider that an object or structure might be re-used in a different area of the standard, it should be included in `definitions`, and referenced. 
 
 ## Naming conventions
 
-We use lower [camelCase](https://en.wikipedia.org/wiki/Camel_case) for property names. E.g. `awardCriteriaDetails`.
-
-We use upper [CamelCase](https://en.wikipedia.org/wiki/Camel_case) for objects directly nested within in the `definitions` section. E.g. `Award`.
-
-We put the qualifier *before* the concept. E.g. `enquiryPeriod` rather than `periodOfEnquiry`.
-
-We use singular for properties pointing to an object or literal value.
-
-We use plural for properties pointing to an array of values. 
-
+See the [schema style guide](schema_style_guide) for guidance on naming fields.
 
 ## ID fields
 
@@ -29,14 +20,14 @@ Any object that is contained within an array MUST have an `id` field.
 
 This is because:
 
-* `id` values play a [special role in the flatten-tool](http://flatten-tool.readthedocs.io/en/latest/unflatten/#relationships-using-identifiers) used to round-trip between JSON and tabular representations of OCDS;
-* `id` values are used to determine [how lists of objects are merged](http://standard.open-contracting.org/latest/en/schema/merging/#identifier-merge) when creating a compiledRelease. 
+* `id` values play a [special role in the flatten-tool](http://flatten-tool.readthedocs.io/en/latest/unflatten/#relationships-using-identifiers) used to round-trip between JSON and tabular representations of OCDS
+* `id` values are used to determine [how lists of objects are merged](http://standard.open-contracting.org/latest/en/schema/merging/#identifier-merge) when creating a compiledRelease.
 
 Objects that are not contained within an array MAY include an `id` property in order to support cross-referencing, or whether the `id` relates to an identifier of the object in the real world. 
 
 ## Types and null
 
-Any non-required property pointing to a literal, array of literals, or single object should support a type of `null`. E.g.:
+Any non-required property pointing to a literal, array of literals, or single object should support a type of `null`. e.g.:
 
 ```json
 { 
@@ -63,14 +54,14 @@ Allowing properties to be `null` is important to the [merging process](http://st
 
 We have adopted a common pattern in OCDS of pairing a codelist, with a `Details` field which can be used for either:
 
-* Free text details on the codelist value;
-* A more detailed set of classifications from a publisher's systems;
+* Free text details on the codelist value
+* A more detailed set of classifications from a publisher's systems
 
 For example, a country may have five procurement procedures: A, B, C, D and E. 
 
 The `procurementMethod` field uses a closed codelist ('open','selective','limited','direct') to which these five procedures should be mapped. The `procurementMethodDetails` field then exists, into which they can input their original, unmapped classifications: A, B, C, D or E. 
 
-Use of `Detail` fields can help increase acceptance of a closed codelist.
+Use of `Details` fields can help increase acceptance of a closed codelist.
 
 ## Additional array
 
@@ -83,5 +74,4 @@ The `additionalX` pattern is used when:
 For example, a source system may record the company registration number and VAT identifier of a company. If we had a single `parties.identifier` object, the data owner would have to pick which identifier to use, and would be omitting data that could help some users to identify an organisation. If we only had an array of `parties.identifiers`, then the data structure for the simple case (only one identifier) becomes more complex, and it is not possible to indicate any priority between the identifiers. 
 
 Using the `additionalX` pattern we have a property (e.g. `property`) referencing an object, paired with an `additionalProperties` property that points to an array of the same object. 
-
 

--- a/docs/standard/index.md
+++ b/docs/standard/index.md
@@ -26,6 +26,7 @@ This section describes the processes for maintaining these assets.
    :glob:
 
    schema
+   conventions
    documentation
    guidance
    translation


### PR DESCRIPTION
This starts adding detail on how to author extensions, and more substantively, adds a page of standard authorship conventions, which address some of the points in #75 in a more generic way. 