### PR TITLE
Add details of extended schema properties

### DIFF
--- a/docs/standard/schema.md
+++ b/docs/standard/schema.md
@@ -45,7 +45,11 @@ The standard's documentation contains a [deprecation policy](http://standard.ope
 
 ## Our extensions to JSON Schema
 
-```eval_rst
-  .. todo::
-    Document the additional properties we added to JSON Schema.
-```
+We use a number of additional JSON Schema properties:
+
+* `codelist`
+* `openCodelist`
+* `deprecated`
+* and a set of merge strategies properties.
+
+These are documented [in the Open Standards for Data handbook](http://os4d.opendataservices.coop/development/schema/#extended-json-schema) and are available via a [meta-schema-patch](https://github.com/open-contracting/standard/tree/HEAD/standard/schema/metaschema). 


### PR DESCRIPTION
I've added a brief note on the additional schema properties we use, and a link to the OS4D handbook where this is documented in more detail. 

If preferred, I can duplicate content from OS4D here - but was trying to stick to principle of keeping things in one place only.