### PR TITLE
Almost good to go

### DIFF
--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -31,11 +31,15 @@ The sheet of a language is edited by the SMEs and the proofreaders. It has the f
 - **Definition**: the definition of the term in the target language. This is not necessarily a translation of the source definition. To improve the usability and efficiency of the glossary, please try to use other terms of the glossary in the definition.
 - **Comment**: any remark the SME may want to add to explain the choice or the definition of the term in the target language.
 
-#### Language variants (es_MX, es_UY, etc.)
+#### Language variants (es-MX, es-GT, fr-BE, etc.)
 
 The sheet of a language variant is edited by the SMEs and the proofreaders. It has the following columns:
 
-TODO
+- Same as languages
+- **Varies from language?**: this cell is automated and it can have the following values:
+    - **no** if the term in the language variant and the base language are the same
+    - **yes => term** if the term in the language variant differs from the one in the base language
+    - **empty** if either the base language or the language variant doesn't have a term yet
 
 
 ### GitHub

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -95,12 +95,15 @@ When new content is added to the documentation and new concepts are introduced i
 
 **Reminder:** a term is a word or group of words that must be used and translated consistently to ensure a good understanding and usage of the content. Synonyms of terms should consequently be avoided. Expressions that are not terms are called *generic* expressions.
 
-| #   | Step name   | Description                                                                                                                 | Tool               |
-| --- | ----------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| 1   | Proposition | The author of new or updated text prepares a list of expressions (words or groups of words) that they consider to be terms. | GitHub issue       |
-| 2   | Validation  | A terminologist validates that the proposed expressions are actually terms.                                                 | GitHub issue       |
-| 3   | Inclusion   | The new terms are added in the working document, checking for duplicates.                                                   | Google spreadsheet |
-
+```eval_rst
+=== =========== =========================================================================================================================== ==================
+#   Step name   Description                                                                                                                 Tool
+=== =========== =========================================================================================================================== ==================
+1   Proposal    The author of new or updated text prepares a list of expressions (words or groups of words) that they consider to be terms. GitHub issue
+2   Review      A terminologist validates that the proposed expressions are actually terms.                                                 GitHub issue
+3   Inclusion   The new terms are added in the working document, checking for duplicates.                                                   Google spreadsheet
+=== =========== =========================================================================================================================== ==================
+```
 
 ### 2. Definition
 
@@ -110,11 +113,13 @@ Using other terms of the glossary in the definitions is a good practice and help
 
 If the definition is copied from an existing publication, please add the URL or reference at the end of the definition.
 
-| #   | Step name  | Description                                                                           | Tool               |
-| --- | ---------- | ------------------------------------------------------------------------------------- | ------------------ |
-| 4   | Definition | The source language SME writes a definition for each term, or copies an existing one. | Google spreadsheet |
-
-
+```eval_rst
+=== ========== ===================================================================================== ==================
+#   Step name  Description                                                                           Tool
+=== ========== ===================================================================================== ==================
+4   Definition The source language SME writes a definition for each term, or copies an existing one. Google spreadsheet
+=== ========== ===================================================================================== ==================
+```
 
 ### 3. Translation
 
@@ -124,20 +129,26 @@ The SME may add a comment in the `comment_xx-XX` column to explain the choice of
 
 The SME pays attention to the definition given for the term, as it may narrow down the meaning and lead to a translation that is more specific than the usual translation of the source term.
 
-
-| #   | Step name   | Description                                                                           | Tool               |
-| --- | ----------- | ------------------------------------------------------------------------------------- | ------------------ |
-| 5   | Translation | The SME translates the terms to the target language and adds comments when necessary. | Google spreadsheet |
+```eval_rst
+=== =========== ===================================================================================== ==================
+#   Step name   Description                                                                           Tool
+=== =========== ===================================================================================== ==================
+5   Translation The SME translates the terms to the target language and adds comments when necessary. Google spreadsheet
+=== =========== ===================================================================================== ==================
+```
 
 ### 4. Proofreading and editing
 
 When the SME is done translating the new terms (or trying to), the proofreader enforces a list of rules to maintain the readability of the terms and the associated comments.
 
-| #   | Step name    | Description                                                                                                               | Tool               |
-| --- | ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| 6   | Translations | The proofreader checks the translations are spelled correctly and written in lower case (proper nouns and acronyms excepted). | Google spreadsheet |
-| 7   | Comments     | The proofreader makes sure the comments are spelled correctly and written as full sentences in sentence case                  | Google spreadsheet |
-
+```eval_rst
+=== ============ ============================================================================================================================= ==================
+#   Step name    Description                                                                                                                   Tool
+=== ============ ============================================================================================================================= ==================
+6   Translations The proofreader checks the translations are spelled correctly and written in lower case (proper nouns and acronyms excepted). Google spreadsheet
+7   Comments     The proofreader makes sure the comments are spelled correctly and written as full sentences in sentence case                  Google spreadsheet
+=== ============ ============================================================================================================================= ==================
+```
 
 ### 5. Publication
 
@@ -147,11 +158,15 @@ Then, they upload the same CSV to Transifex.
 
 Steps 1 and 2 of this stage can be scripted.
 
-| #   | Step name                 | Description                                                                      | Tool               |
-| --- | ------------------------- | -------------------------------------------------------------------------------- | ------------------ |
-| 8   | CSV download              | File > Download as... > Comma-separated values                                   | Google spreadsheet |
-| 9   | GitHub commit             | The CSV file replaces the previous one for the selected language and is commited | Git                |
-| 10  | Transifex glossary update | The CSV file is uploaded to Transifex glossary, deleting the previous entries    | Transifex          |
+```eval_rst
+=== ========================= ================================================================================= ==================
+#   Step name                 Description                                                                       Tool
+=== ========================= ================================================================================= ==================
+8   CSV download              File > Download as... > Comma-separated values                                    Google spreadsheet
+9   GitHub commit             The CSV file replaces the previous one for the selected language and is committed Git
+10  Transifex glossary update The CSV file is uploaded to Transifex glossary, deleting the previous entries     Transifex
+=== ========================= ================================================================================= ==================
+```
 
 ### 6. Management tasks
 

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -80,6 +80,10 @@ They are a native speaker of the target language.
 
 The proofreader may be an overseer, but not necessarily.
 
+### Publisher
+
+The publisher gathers the data from the spreadsheet and makes sure it gets published.
+
 ## Process
 
 ### 1. Proposal, review, inclusion
@@ -134,7 +138,7 @@ When the SME is done translating the new terms (or trying to), the proofreader e
 
 ### 5. Publication
 
-Once the translations are proofread and edited, *someone* downloads the working document as a CSV file and replaces the previous file in the GitHub repository.
+Once the translations are proofread and edited, the publisher downloads the working document as a CSV file and replaces the previous file in the GitHub repository.
 
 Then, they upload the same CSV to Transifex.
 

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -41,12 +41,15 @@ The sheet of a language variant is edited by the SMEs and the proofreaders. It h
     - **yes => term** if the term in the language variant differs from the one in the base language
     - **empty** if either the base language or the language variant doesn't have a term yet
 
-
 ### GitHub
 
 GitHub is used as the source of truth for OCP terminology. The terms, definitions and translations that are pushed to the repository have been previously spellchecked.
 
 The benefit of using Git is that it neatly tracks the changes made to the files and it incorporates a convenvient issue tracker to track the progression of certain tasks.
+
+### Transifex
+
+[Transifex](https://www.transifex.com/OpenDataServices/public/) is the tool currently used by the Open Contracting Partnership to manage the translation of their content. One of its features is a glossary that enables translators to access the translated terms when translating.
 
 ## Roles overview
 

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -68,11 +68,9 @@ If they work on the definitions, they are fluent in English.
 
 If they translate the terms, they are fluent in the target language. They understand written English and are able to find terms in their language that equivalent to the source English terms.
 
-### Language owner
+### Overseer
 
-The language owner oversees the translations of one or more variations of a language. They are the reference contacts for the subject matter experts (SMEs) who translate the terms.
-
-They are fluent practioners of the language they oversee.
+The overseer oversees the translation of the terms of base languages and language variants. They are the reference contacts for the subject matter experts (SMEs) who translate the terms and the proofreaders.
 
 ### Proofreader
 
@@ -80,7 +78,7 @@ The proofreader ensures that the translated terms and their comments are well wr
 
 They are a native speaker of the target language.
 
-The proofreader may be a language owner, but not necessarily.
+The proofreader may be an overseer, but not necessarily.
 
 ## Process
 
@@ -153,7 +151,8 @@ Steps 1 and 2 of this stage can be scripted.
 Certain tasks are not directly related to the production of the glossary, but are necessary for good coordination:
 
 - The author informs the terminologist that a new batch of terms is ready for review.
-- *Someone* informs the translators that new terms should be translated.
-- The language owners manage the permissions for each sheet to enable the translators to translate.
-- The language owners inform *someone* that a certain batch of terms is translated, proofread and edited, ready to be pushed to the GitHub repository.
-- *Someone* informs *someone* that batch of terms has been pushed to GitHub, ready to be published to Transifex.
+- The terminologists inform the overseers that new terms should be translated.
+- The overseers inform the SMEs that new terms need to be translated.
+- The overseers inform the proofreaders that the translated terms to be proofread.
+- The overseers manage the permissions for each sheet and give the SMEs and proofreaders the rights to edit the relevant sheets.
+- The overseers inform the publishers that a certain batch of terms is translated, proofread and edited, ready to be pushed to the GitHub repository and Transifex.

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -8,7 +8,7 @@ In order to use key terms consistently across the standard documentation and OCP
 
 ### Google spreadsheet
 
-The Google spreadsheet is divided in sheets. Each term is identified by an ID to enable the reconciliation of the terms across languages and enable the management of homographs (different terms that have the same spelling).
+[The Google spreadsheet](https://docs.google.com/spreadsheets/d/1PvlA2WWtP9KJpnkhuYGx5ExHmHwwvaA54VX62piF86k/edit) is divided in sheets. Each term is identified by an ID to enable the reconciliation of the terms across languages and enable the management of homographs (different terms that have the same spelling).
 
 All the sheets are publicly readable and can be commented by anyone.
 

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -18,10 +18,10 @@ The Source sheet is edited by the terminologist and the SMEs and proofreaders in
 
 - **ID**: the ID of a term never changes. When a new term is added, it takes the next available ID number.
 - **Term**: the term, in its canonical form (lower case, singular, infinitive)
-- **Definition**: the definition of the term **within the scope of OCDS documentation**. To improve the usability and efficiency of the glossary, please try to use other terms of the glossary in the definition.
-- **Comment**: any remark the terminologist may want to add to help translating this term
+- **Definition**: the definition of the term **within the scope of OCDS documentation**. To improve the usability and efficiency of the glossary, please try to use other terms of the glossary in the definition. The definition cell is a good place to give concise examples.
+- **Comment**: any remark the terminologist may want to add to help translating this term or a URL to information about the term.
 
-#### Languages (es, fr, etc.)
+#### Base languages (es, fr, etc.)
 
 The sheet of a language is edited by the SMEs and the proofreaders. It has the following columns:
 
@@ -154,9 +154,11 @@ Steps 1 and 2 of this stage can be scripted.
 
 Certain tasks are not directly related to the production of the glossary, but are necessary for good coordination:
 
-- The author informs the terminologist that a new batch of terms is ready for review.
+- The authors inform the terminologists that a new batch of terms is ready for review.
 - The terminologists inform the overseers that new terms should be translated.
 - The overseers inform the SMEs that new terms need to be translated.
 - The overseers inform the proofreaders that the translated terms to be proofread.
 - The overseers manage the permissions for each sheet and give the SMEs and proofreaders the rights to edit the relevant sheets.
 - The overseers inform the publishers that a certain batch of terms is translated, proofread and edited, ready to be pushed to the GitHub repository and Transifex.
+
+At all stages, every person involved uses ranges or list of term IDs to clearly express what terms need to be processed.

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -71,9 +71,9 @@ If they work on the definitions, they are fluent in English.
 
 If they translate the terms, they are fluent in the target language. They understand written English and are able to find terms in their language that equivalent to the source English terms.
 
-### Overseer
+### Coordinator
 
-The overseer oversees the translation of the terms of base languages and language variants. They are the reference contacts for the subject matter experts (SMEs) who translate the terms and the proofreaders.
+The coordinator oversees the translation of the terms of base languages and language variants. They are the reference contact for the subject matter experts (SMEs) who translate the terms and for the proofreaders.
 
 ### Proofreader
 
@@ -81,7 +81,7 @@ The proofreader ensures that the translated terms and their comments are well wr
 
 They are a native speaker of the target language.
 
-The proofreader may be an overseer, but not necessarily.
+The proofreader may be a coordinator, but not necessarily.
 
 ### Publisher
 
@@ -158,10 +158,10 @@ Steps 1 and 2 of this stage can be scripted.
 Certain tasks are not directly related to the production of the glossary, but are necessary for good coordination:
 
 - The authors inform the terminologists that a new batch of terms is ready for review.
-- The terminologists inform the overseers that new terms should be translated.
-- The overseers inform the SMEs that new terms need to be translated.
-- The overseers inform the proofreaders that the translated terms to be proofread.
-- The overseers manage the permissions for each sheet and give the SMEs and proofreaders the rights to edit the relevant sheets.
-- The overseers inform the publishers that a certain batch of terms is translated, proofread and edited, ready to be pushed to the GitHub repository and Transifex.
+- The terminologists inform the coordinators that new terms should be translated.
+- The coordinators inform the SMEs that new terms need to be translated.
+- The coordinators inform the proofreaders that the translated terms to be proofread.
+- The coordinators manage the permissions for each sheet and give the SMEs and proofreaders the rights to edit the relevant sheets.
+- The coordinators inform the publishers that a certain batch of terms is translated, proofread and edited, ready to be pushed to the GitHub repository and Transifex.
 
 At all stages, every person involved uses ranges or list of term IDs to clearly express what terms need to be processed.

--- a/docs/standard/terminology.md
+++ b/docs/standard/terminology.md
@@ -95,15 +95,12 @@ When new content is added to the documentation and new concepts are introduced i
 
 **Reminder:** a term is a word or group of words that must be used and translated consistently to ensure a good understanding and usage of the content. Synonyms of terms should consequently be avoided. Expressions that are not terms are called *generic* expressions.
 
-```eval_rst
-=== =========== =========================================================================================================================== ==================
-#   Step name   Description                                                                                                                 Tool
-=== =========== =========================================================================================================================== ==================
-1   Proposal    The author of new or updated text prepares a list of expressions (words or groups of words) that they consider to be terms. GitHub issue
-2   Review      A terminologist validates that the proposed expressions are actually terms.                                                 GitHub issue
-3   Inclusion   The new terms are added in the working document, checking for duplicates.                                                   Google spreadsheet
-=== =========== =========================================================================================================================== ==================
-```
+| #   | Step name   | Description                                                                                                                 | Tool               |
+| --- | ----------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| 1   | Proposition | The author of new or updated text prepares a list of expressions (words or groups of words) that they consider to be terms. | GitHub issue       |
+| 2   | Validation  | A terminologist validates that the proposed expressions are actually terms.                                                 | GitHub issue       |
+| 3   | Inclusion   | The new terms are added in the working document, checking for duplicates.                                                   | Google spreadsheet |
+
 
 ### 2. Definition
 
@@ -113,13 +110,11 @@ Using other terms of the glossary in the definitions is a good practice and help
 
 If the definition is copied from an existing publication, please add the URL or reference at the end of the definition.
 
-```eval_rst
-=== ========== ===================================================================================== ==================
-#   Step name  Description                                                                           Tool
-=== ========== ===================================================================================== ==================
-4   Definition The source language SME writes a definition for each term, or copies an existing one. Google spreadsheet
-=== ========== ===================================================================================== ==================
-```
+| #   | Step name  | Description                                                                           | Tool               |
+| --- | ---------- | ------------------------------------------------------------------------------------- | ------------------ |
+| 4   | Definition | The source language SME writes a definition for each term, or copies an existing one. | Google spreadsheet |
+
+
 
 ### 3. Translation
 
@@ -129,26 +124,20 @@ The SME may add a comment in the `comment_xx-XX` column to explain the choice of
 
 The SME pays attention to the definition given for the term, as it may narrow down the meaning and lead to a translation that is more specific than the usual translation of the source term.
 
-```eval_rst
-=== =========== ===================================================================================== ==================
-#   Step name   Description                                                                           Tool
-=== =========== ===================================================================================== ==================
-5   Translation The SME translates the terms to the target language and adds comments when necessary. Google spreadsheet
-=== =========== ===================================================================================== ==================
-```
+
+| #   | Step name   | Description                                                                           | Tool               |
+| --- | ----------- | ------------------------------------------------------------------------------------- | ------------------ |
+| 5   | Translation | The SME translates the terms to the target language and adds comments when necessary. | Google spreadsheet |
 
 ### 4. Proofreading and editing
 
 When the SME is done translating the new terms (or trying to), the proofreader enforces a list of rules to maintain the readability of the terms and the associated comments.
 
-```eval_rst
-=== ============ ============================================================================================================================= ==================
-#   Step name    Description                                                                                                                   Tool
-=== ============ ============================================================================================================================= ==================
-6   Translations The proofreader checks the translations are spelled correctly and written in lower case (proper nouns and acronyms excepted). Google spreadsheet
-7   Comments     The proofreader makes sure the comments are spelled correctly and written as full sentences in sentence case                  Google spreadsheet
-=== ============ ============================================================================================================================= ==================
-```
+| #   | Step name    | Description                                                                                                               | Tool               |
+| --- | ------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| 6   | Translations | The proofreader checks the translations are spelled correctly and written in lower case (proper nouns and acronyms excepted). | Google spreadsheet |
+| 7   | Comments     | The proofreader makes sure the comments are spelled correctly and written as full sentences in sentence case                  | Google spreadsheet |
+
 
 ### 5. Publication
 
@@ -158,15 +147,11 @@ Then, they upload the same CSV to Transifex.
 
 Steps 1 and 2 of this stage can be scripted.
 
-```eval_rst
-=== ========================= ================================================================================= ==================
-#   Step name                 Description                                                                       Tool
-=== ========================= ================================================================================= ==================
-8   CSV download              File > Download as... > Comma-separated values                                    Google spreadsheet
-9   GitHub commit             The CSV file replaces the previous one for the selected language and is committed Git
-10  Transifex glossary update The CSV file is uploaded to Transifex glossary, deleting the previous entries     Transifex
-=== ========================= ================================================================================= ==================
-```
+| #   | Step name                 | Description                                                                      | Tool               |
+| --- | ------------------------- | -------------------------------------------------------------------------------- | ------------------ |
+| 8   | CSV download              | File > Download as... > Comma-separated values                                   | Google spreadsheet |
+| 9   | GitHub commit             | The CSV file replaces the previous one for the selected language and is commited | Git                |
+| 10  | Transifex glossary update | The CSV file is uploaded to Transifex glossary, deleting the previous entries    | Transifex          |
 
 ### 6. Management tasks
 


### PR DESCRIPTION
I have added:

- Documentation on language variants
- Renaming and redefinition of the role of the overseer (formerly *language owner*)
- Establishment of the role of the publisher (formerly *someone*)
- Added a link to the OCP glossary spreadsheet
- Added a description of the Transifex tool 

What still lacks is the Github repository used for the glossary.

Shall we use an existing one or create a dedicated one?