### PR TITLE
Changing name of get-readmes.py to fetch_updated_extension_docs.py

### DIFF
--- a/docs/standard/technical/deployment.md
+++ b/docs/standard/technical/deployment.md
@@ -71,10 +71,10 @@ Then, create a new release of the extension registry to point to the new release
 
 Update the standard's [changelog](http://standard.open-contracting.org/latest/en/schema/changelog/#changelog) with a summary of the changes to core extensions.
 
-Edit `standard/docs/en/extensions/get-readmes.py` and set `EXTENSION_GIT_REF` to e.g. `v1.1.1`, then pull extensions' Markdown files into the standard:
+Edit `standard/docs/en/extensions/fetch_updated_extension_docs.py` and set `EXTENSION_GIT_REF` to e.g. `v1.1.1`, then pull extensions' Markdown files into the standard:
 
 ```bash
-python standard/docs/en/extensions/get-readmes.py
+python standard/docs/en/extensions/fetch_updated_extension_docs.py
 ```
 
 Set the documentation build process to use the new extension registry tag, by editing `standard/docs/en/conf.py` and setting `extension_registry_git_ref` to e.g. `v1.1.1`.


### PR DESCRIPTION
I'd missed noticing get-readmes.py and it's purpose wasn't 100% intuitive from a glance.

In the draft 1.1.3 branch I've updated this script to also get codelists, so I've also renamed the script to fetch_updated_extension_docs.py and updating the docs here to reflect that. 