### PR TITLE
Abbreviate description templates

### DIFF
--- a/docs/coding/index.md
+++ b/docs/coding/index.md
@@ -35,6 +35,58 @@ with open(path, 'w') as f:
     f.write('\n')
 ```
 
+## Python packages
+
+* Use `install_requires` and `extras_require` in `setup.py` instead of `requirements.txt`
+* Sort requirements alphabetically
+
+If the package isn't distributed on PyPi, use this template `setup.py`, adding arguments like `entry_points`, `extras_require` and `namespace_packages` as needed:
+
+```python
+from setuptools import setup, find_packages
+
+setup(
+    name='NAME',
+    version='0.0.0',
+    packages=find_packages(),
+    install_requires=[
+        'REQUIREMENT',
+    ],
+)
+```
+
+If the package is distributed on PyPi, use this template `setup.py`:
+
+```python
+from setuptools import setup, find_packages
+
+with open('README.rst') as f:
+    long_description = f.read()
+
+setup(
+    name='NAME',
+    version='0.0.0',
+    author='Open Contracting Partnership',
+    author_email='data@open-contracting.org',
+    url='https://github.com/open-contracting/REPOSITORY',
+    description='DESCRIPTION',
+    license='BSD',
+    packages=find_packages(),
+    long_description=long_description,
+    install_requires=[
+        'REQUIREMENT',
+    ],
+    classifiers=[
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3.6',
+    ],
+)
+```
+
+To change a readme from Markdown to reStructuredText, install `pandoc` and run:
+
+    pandoc --from=markdown --to=rst --output=README.rst README.md
+
 ## Linting
 
 [standard-maintenance-scripts](https://github.com/open-contracting/standard-maintenance-scripts) performs [linting](https://github.com/open-contracting/standard-maintenance-scripts/blob/master/tests/script.sh) of Python files. The linting of Markdown files is disabled. To perform periodic Markdown linting, you must:

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -87,11 +87,11 @@ The following description templates should be used for common fields in the sche
 
 For single values:
 
-> A value from the <codelist_name> codelist indicating <purpose of codelist>. Further information may be provided in the <codelistDetails_name> field.
+    A value from the <codelist_name> codelist indicating <purpose of codelist>. Further information may be provided in the <codelistDetails_name> field.
 
 For multiple values:
 
-> One or more values from the <codelist_name> codelist indicating <purpose of codelist>. Further information may be provided in the <codelistDetails_name> field.
+    One or more values from the <codelist_name> codelist indicating <purpose of codelist>. Further information may be provided in the <codelistDetails_name> field.
 
 **Example:**
 
@@ -101,7 +101,7 @@ For multiple values:
 
 For the `id` property of items in arrays:
 
-> A locally unique identifier for this <object_name>. Used to track changes to this <object_name> and to [merge](http://standard.open-contracting.org/latest/en/schema/merging/#merging) multiple releases to create a record.
+    A locally unique identifier for this <object_name>. Used to track changes to this <object_name> and to [merge](http://standard.open-contracting.org/latest/en/schema/merging/#merging) multiple releases to create a record.
 
 **Example:**
 
@@ -111,13 +111,13 @@ For the `id` property of items in arrays:
 
 For the `title` property of an object:
 
-> A title for this <object_name>.
+    A title for this <object_name>.
 
 #### Descriptions
 
 For the `description` property of an object:
 
-> A description of this <object_name>. Structured information should be provided in <related_fields>.
+    A description of this <object_name>. Structured information should be provided in <related_fields>.
 
 **Example:**
 
@@ -127,13 +127,13 @@ For the `description` property of an object:
 
 For the `documents` property of an object:
 
-> All documents and attachments related to this <object_name>, including any official notices.
+    All documents and attachments related to this <object_name>, including any official notices.
 
 #### Milestones
 
 For the `milestones` property of an object:
 
-> A list of important dates or events associated with this <object_name>.
+    A list of important dates or events associated with this <object_name>.
 
 ## Handbook style guide
 

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -62,7 +62,7 @@ Use American English (e.g. 'organization' rather than 'organisation') unless we 
   * "One or more values from the submissionMethod codelist indicating the method(s) by which bids can be submitted" uses a neutral voice.
   * "Specify the method(s) by which bids can be submitted" addresses publishers rather than users.
 * Descriptions should balance the needs of expert users, for whom the description serves to assure that use of the field or code is appropriate, and non-expert users, for whom the description of the code serves to help them understand how the field or code is used and whether it is likely to contain the information they are looking for.
-* Subsequent sentences may provide information or guidance to assist publishers to use the field effectively or users to interpret the field effectively
+* Subsequent sentences may provide information or guidance to assist publishers to use the field effectively or users to interpret the field effectively.
 * Guidance sentences should be grounded in clear user needs and implementation experience of common pitfalls or errors.
 * For fields or codes whose names and titles use complex or specialist language, consider providing an example to aid non-expert users, e.g.
 
@@ -83,7 +83,7 @@ guaranteeReports  Fiscal commitments and contingent liabilities reports Reports 
 
 Descriptions for similar properties or codes should be consistent with each other where possible, without discarding information relevant to a specific field.
 
-The following examples can be used to inform descriptions for common types of field in the schema. Additional information, specific to a particular field, should be provided in a separate sentence after the primary description of the field.
+The following examples can be used to inform descriptions for common types of fields in the schema. Additional information, specific to a particular field, should be provided in a separate sentence after the primary description of the field.
 
 #### Codelists
 

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -32,7 +32,7 @@ Use American English (e.g. 'organization' rather than 'organisation') unless we 
 * We use upper [CamelCase](https://en.wikipedia.org/wiki/Camel_case) for objects directly nested within the `definitions` section, e.g. `Award`.
 * We put the qualifier *before* the concept, e.g. `enquiryPeriod` rather than `periodOfEnquiry`.
 * We use singular for properties pointing to an object or literal value.
-* We use plural for properties pointing to an array of values. 
+* We use plural for properties pointing to an array of values.
 * Property and object names should not include the name of the parent object, e.g. `title` not `tenderTitle`, `description` not `awardDescription`, etc.
 * Date fields should use the `"format": "date-time"` key to enforce use of ISO8601
 * The `period` object should be used in place of `year` or `month` fields
@@ -58,11 +58,12 @@ Use American English (e.g. 'organization' rather than 'organisation') unless we 
 
 ### Schema and codelist descriptions
 
-* Descriptions should be treated as definitions and written in a neutral voice, rather than addressing a particular audience, e.g. for `tender/submissionMethod`.
+* The first sentence of a description should be descriptive of the contents of the field and written in a neutral voice, rather than addressing a particular audience, e.g. for `tender/submissionMethod`.
   * "One or more values from the submissionMethod codelist indicating the method(s) by which bids can be submitted" uses a neutral voice.
-  * "Specify the method(s) by which bids can be submitted" addresses publishers rather than users. 
-* Where it is necessary to provide publisher or user-specific information in a description this should be provided in a separate sentence after the primary definition.
+  * "Specify the method(s) by which bids can be submitted" addresses publishers rather than users.
 * Descriptions should balance the needs of expert users, for whom the description serves to assure that use of the field or code is appropriate, and non-expert users, for whom the description of the code serves to help them understand how the field or code is used and whether it is likely to contain the information they are looking for.
+* Subsequent sentences may provide information or guidance to assist publishers to use the field effectively or users to interpret the field effectively
+* Guidance sentences should be grounded in clear user needs and implementation experience of common pitfalls or errors.
 * For fields or codes whose names and titles use complex or specialist language, consider providing an example to aid non-expert users, e.g.
 
 ```eval_rst
@@ -75,13 +76,14 @@ guaranteeReports  Fiscal commitments and contingent liabilities reports Reports 
 
 * Descriptions should not link to definitions provided on external websites.
 * Descriptions should be concise and avoid using exhaustive lists.
-* Schema descriptions should not explicitly state whether a field is required or optional.
-* Descriptions for similar properties or codes should be consistent with each other.
+* Descriptions should not explicitly state whether a field is required or optional.
 * Descriptions should not simply restate the title or name of a property or code.
 
 ### Description templates
 
-The following description templates should be used for common fields in the schema. Additional information, specific to a particular field, may be provided in a separate sentence after the primary definition for the field.
+Descriptions for similar properties or codes should be consistent with each other where possible, without discarding information relevant to a specific field.
+
+The following examples can be used to inform descriptions for common types of field in the schema. Additional information, specific to a particular field, should be provided in a separate sentence after the primary description of the field.
 
 #### Codelists
 
@@ -107,7 +109,7 @@ For the `id` property of items in arrays:
 
 > A locally unique identifier for this document. Used to track changes to this document and to [merge](http://standard.open-contracting.org/latest/en/schema/merging/#merging) multiple releases to create a record.
 
-#### Title
+#### Titles
 
 For the `title` property of an object:
 
@@ -119,9 +121,11 @@ For the `description` property of an object:
 
     A description of this <object_name>. Structured information should be provided in <related_fields>.
 
-**Example:**
+**Examples:**
 
-> A description of this tender. Structured information should be provided in the items array.
+> A description of this tender. Structured information should be provided in the items array. Descriptions should be short and easy to read. Avoid using ALL CAPS.
+
+> A description of this document. Descriptions should not exceed 250 words. In the event the document is not accessible online, the description field may be used to describe arrangements for obtaining a copy of the document.
 
 #### Documents
 

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -111,17 +111,17 @@ For the `id` property of items in arrays:
 
 For the `title` property of an object:
 
-> A title for this <object_name>. Titles will often be displayed in consuming application to help users find the <object_name> they are looking for.
+> A title for this <object_name>.
 
 #### Descriptions
 
 For the `description` property of an object:
 
-> A short and easy-to-read summary of this <object_name>. Structured information should be provided in <related_fields>. Descriptions should not exceed 250 words.
+> A description of this <object_name>. Structured information should be provided in <related_fields>.
 
 **Example:**
 
-> A short and easy-to-read summary of this tender. Structured information should be provided in the items array. Descriptions should not exceed 250 words.
+> A description of this tender. Structured information should be provided in the items array.
 
 #### Documents
 

--- a/docs/meta/style_guide.md
+++ b/docs/meta/style_guide.md
@@ -79,7 +79,7 @@ guaranteeReports  Fiscal commitments and contingent liabilities reports Reports 
 * Descriptions should not explicitly state whether a field is required or optional.
 * Descriptions should not simply restate the title or name of a property or code.
 
-### Description templates
+### Example descriptions
 
 Descriptions for similar properties or codes should be consistent with each other where possible, without discarding information relevant to a specific field.
 


### PR DESCRIPTION
@duncandewhurst While reviewing https://github.com/open-contracting/ocds_requirements_extension/pull/24/files, I found that the template for title and description didn't work for the variety of titles and descriptions we encounter.

> Titles will often be displayed in consuming application to help users find the <object_name> they are looking for.

This is essentially describing the meaning of the word 'title' and the function of naming things.

> Descriptions should not exceed 250 words.

We have a lot of description fields to which publishers map, for example, the full text of a notice, which often exceed 250 words. At minimum, this shouldn't use a normative keyword.

> short and easy-to-read summary

Given the above, it's not necessarily short or a summary, and if it's a copy of existing data (rather than newly authored data), there's no guarantee that it's easy-to-read.

If we want to encourage publishers to be short and easy-to-read, we can do that in other guidance, outside the schema.