### PR TITLE
Remove empty guidance page

### DIFF
--- a/docs/standard/guidance.md
+++ b/docs/standard/guidance.md
@@ -1,6 +1,0 @@
-# Guidance
-
-```eval_rst
-  .. todo::
-    Describe the guidance resources associated with OCDS - including publication levels.
-```


### PR DESCRIPTION
Its contents are "Describe the guidance resources associated with OCDS - including publication levels."

I'm not sure what the intention was for this page. If there's something to add here, we should create an issue, instead of having an empty page.

cc @timgdavies as creator of the page.