### PR TITLE
Updating guidance on versioning core extensions

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -41,6 +41,8 @@ The *core* extensions are versioned using [Git tags](https://git-scm.com/book/en
 
 This is particularly important for new versions of the standard, as each version's documentation should point to specific versions of its extensions. See [creating new releases of core extensions](../standard/technical/deployment#create-new-releases-of-core-extensions).
 
+A new release of *core* extension can only be made as part of the OCDS governance process. Draft work on a new core extension should be presented with an `-alpha` suffix. When you have confidence (as a result of engagement with the community, and testing) that the approach taken by an update to a core extension is likely to receive approval in a future governance process, a `-beta` suffix may be added to indicate to early-adopters that they can consider use of this instead of the version pinned in the most recent version of the standard. 
+
 Community extensions, on the other hand, are externally maintained and not associated to each version of the standard.
 
 ## Reporting issues on extensions

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1,27 +1,14 @@
 # Extensions
 
-An OCDS release or record package may declare one or more extensions. Extensions can add to the schema, add new codelists, or add entries to existing codelists. 
+An OCDS release or record package can declare one or more extensions. Extensions extend the standard, by adding new fields, new codelists or new codes to open codelists. Extensions can be brought together as [profiles](../profiles).
 
-See the [standard documentation](http://standard.open-contracting.org/latest/en/extensions/) for definitions of core, community and local extensions.
+## Creating an extension
 
-In addition, a collection of extensions may be packaged together as an **OCDS profile**. When used as part of a profile, extensions may additionally remove scheme elements and codelist entries. 
+[Read this draft policy](https://docs.google.com/document/d/1zvR1PDefO6yTK28uKA6XCnxMLiC9oiEeb3uFjHuRyqI/edit) to decide whether to create a [core, community or local extension](http://standard.open-contracting.org/latest/en/extensions/).
 
-The structure of an extension is documented in the [standard extension template](https://github.com/open-contracting/standard_extension_template/blob/master/README.md).
+To create the extension, [use the extension template](https://github.com/open-contracting/standard_extension_template/blob/master/README.md), which also documents the structure of extensions.
 
-## When to create a *core* extension
-
-* An extension can be authored to limit 'scope creep' of the core standard, especially in cases where we lack implementation experience with the proposed changes. The extension may serve as a way to externalize the risk of permanent changes to the core standard.
-* An extension may lower risks associated to the 'compliance mindset' (e.g. if a publisher sees bids in the standard but is prevented by law from publishing bids, they may object to adopting the standard entirely).
-* An extension externalizes confusing, complex, or non-universal concepts. For example, lots are not universal and may be complex. Gazetteers (as in the location extension) are not universal.
-* An extension can be a means of breaking backwards compatibility (for example, removing codes from codelists), which would otherwise require a 2.0 version of OCDS.
-
-## Creating extensions
-
-It is recommended to use the [standard extension template](https://github.com/open-contracting/standard_extension_template). All *core* extensions are released under the [Apache License 2.0](https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/master/LICENSE).
-
-The mechanism for extending a core JSON Schema file, like `release-schema.json`, is to author a small, similar-looking JSON Schema file, that is applied to the core file using [JSON Merge Patch](https://tools.ietf.org/html/rfc7396).
-
-When creating a *core* extension, the GitHub repository should have issues disabled (see [reporting issues on extensions](#reporting-issues-on-extensions) below). Its `README.md` file should include the following text:
+If you're creating a *core* extension, use the [Apache License 2.0](https://raw.githubusercontent.com/open-contracting/ocds_process_title_extension/master/LICENSE), disable issues on the GitHub repository (see [reporting issues on extensions](#reporting-issues-on-extensions) below) and include the following text in its `README.md` file:
 
 ```markdown
 ## Issues
@@ -29,21 +16,13 @@ When creating a *core* extension, the GitHub repository should have issues disab
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 ```
 
-When creating a community extension, there are no requirements regarding issues.
+To publish the extension, [add it the extension registry](https://github.com/open-contracting/extension_registry).
 
-## Publishing extensions
+## Changing *core* extensions
 
-Once an extension is created, it should be added to the extension registry - an inventory of extensions that is included in the [standard's documentation](http://standard.open-contracting.org/latest/en/extensions/) - [as described in its readme](https://github.com/open-contracting/extension_registry).
+The versioning of core extensions is under discussion in a [pull request](https://github.com/open-contracting/standard/pull/674). For now, see [creating new versions of core extensions](../standard/technical/deployment#create-new-versions-of-core-extensions).
 
-### Publishing new versions of extensions
-
-The *core* extensions are versioned using [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) and made available as [releases on GitHub](https://help.github.com/categories/releases/) (which depend on tags).
-
-This is particularly important for new versions of the standard, as each version's documentation should point to specific versions of its extensions. See [creating new releases of core extensions](../standard/technical/deployment#create-new-releases-of-core-extensions).
-
-A new release of *core* extension can only be made as part of the OCDS governance process. Draft work on a new core extension should be presented with an `-alpha` suffix. When you have confidence (as a result of engagement with the community, and testing) that the approach taken by an update to a core extension is likely to receive approval in a future governance process, a `-beta` suffix may be added to indicate to early-adopters that they can consider use of this instead of the version pinned in the most recent version of the standard. 
-
-Community extensions, on the other hand, are externally maintained and not associated to each version of the standard.
+Between OCDS versions, changes can be made to the ['live' version](https://github.com/open-contracting/extension_registry#extension_versionscsv) of a core extension; this can be treated as a working draft of a future version.
 
 ## Reporting issues on extensions
 

--- a/docs/standard/technical/deployment.md
+++ b/docs/standard/technical/deployment.md
@@ -50,32 +50,19 @@ bundle exec rake release:review_extensions
     You can skip this step if you are not releasing a new major, minor or patch version.
 ```
 
-The governance process will establish whether to create a new release of a core extension for this OCDS version. Each release of the standard should refer to specific versions of each [core extension](http://standard.open-contracting.org/latest/en/extensions/#core-extensions).
+The governance process will establish whether to create a new release of a core extension for this OCDS version. Each release of the standard should refer to a specific versions of each [core extension](http://standard.open-contracting.org/latest/en/extensions/#core-extensions).
 
-For each *core* extension:
+Between versions of the standard, `-alpha` and `-beta` releases of a core extension may be made. A full release of a core extension should only be made as part of the governance process for a standard upgrade. 
 
-1. From the list of releases, click *Draft a new release*
-1. In *Tag version*, enter the OCDS version in *vmajor.minor.patch* format, e.g. `v1.1.1`
-1. In *Release title*, enter a title, e.g. "Fixed version for OCDS 1.1.1"
-1. Enter a summary of changes, e.g. "Typo fixes", and click *Publish release*
+##### Worked example
 
-Instead of navigating the website, run this Rake task, which will use the extension's changelog as the release message and "Fixed version for OCDS X.X.X" as the release title:
+If the latest version of OCDS is 1.1, and it references version 1.1 of the bids and enquiries extension, and proposals are made for changes to the bids extension.
 
-```bash
-bundle exec rake release:release_extensions REF=v1.1.1
-```
+* A version `1.2-alpha` of the bids extension may be created;
+* If there is consensus that the changes should be considered as a core extension against OCDS 1.2, then a `1.2-beta` release of the bids extension may be made;
+* Bids `1.2-beta` should be considered as part of the OCDS 1.2 governance process, and if approved, bids `1.2` released alongside OCDS `1.2`. 
 
-If you make a mistake, you can undo the release with:
-
-```bash
-bundle exec rake release:undo_release_extensions REF=v1.1.1 REPOS=repo1,repo2
-```
-
-Then, add the new releases to the [extension registry](https://github.com/open-contracting/extension_registry). To quickly generate the content of `extension_versions.csv` with the new releases of core extensions, run:
-
-```bash
-bundle exec rake registry_extension_versions
-```
+By contrast, if no changes are required to the enquiries extension, then OCDS 1.2 would reference enquiries version `1.1`. 
 
 ### 2. Perform periodic updates, if appropriate
 

--- a/docs/standard/technical/deployment.md
+++ b/docs/standard/technical/deployment.md
@@ -43,26 +43,38 @@ Instead of navigating the website, run this Rake task to get links to pull reque
 bundle exec rake release:review_extensions
 ```
 
-#### Create new releases of core extensions
+#### Create new versions of core extensions
 
 ```eval_rst
   .. note::
     You can skip this step if you are not releasing a new major, minor or patch version.
 ```
 
-The governance process will establish whether to create a new release of a core extension for this OCDS version. Each release of the standard should refer to a specific versions of each [core extension](http://standard.open-contracting.org/latest/en/extensions/#core-extensions).
+Each OCDS version refers to a specific version of each [core extension](http://standard.open-contracting.org/latest/en/extensions/#core-extensions). The [governance process](http://standard.open-contracting.org/latest/en/support/governance/#versions) will establish whether to create a new version of a core extension for this OCDS version.
 
-Between versions of the standard, `-alpha` and `-beta` releases of a core extension may be made. A full release of a core extension should only be made as part of the governance process for a standard upgrade. 
+For each *core* extension for which to create a new version:
 
-##### Worked example
+1. From the list of releases, click *Draft a new release*
+1. In *Tag version*, enter the version number in *vmajor.minor.patch* format, e.g. `v1.1.1`
+1. Enter a summary of changes, e.g. "Typo fixes", and click *Publish release*
 
-If the latest version of OCDS is 1.1, and it references version 1.1 of the bids and enquiries extension, and proposals are made for changes to the bids extension.
+Instead of navigating the website, use this Rake task, which will use the extension's changelog as the release message:
 
-* A version `1.2-alpha` of the bids extension may be created;
-* If there is consensus that the changes should be considered as a core extension against OCDS 1.2, then a `1.2-beta` release of the bids extension may be made;
-* Bids `1.2-beta` should be considered as part of the OCDS 1.2 governance process, and if approved, bids `1.2` released alongside OCDS `1.2`. 
+```bash
+bundle exec rake release:release_extensions REF=v1.1.1 REPOS=repo1,repo2
+```
 
-By contrast, if no changes are required to the enquiries extension, then OCDS 1.2 would reference enquiries version `1.1`. 
+If you make a mistake, you can undo the release with:
+
+```bash
+bundle exec rake release:undo_release_extensions REF=v1.1.1 REPOS=repo1,repo2
+```
+
+Then, add the new releases to the [extension registry](https://github.com/open-contracting/extension_registry). To quickly generate the content of `extension_versions.csv` with the new releases of core extensions, run:
+
+```bash
+bundle exec rake registry_extension_versions
+```
 
 ### 2. Perform periodic updates, if appropriate
 


### PR DESCRIPTION
Following the agreement on approach to versioning core extensions as discussed in https://github.com/open-contracting/standard/pull/674 this update removes references to creating versions of each core extension for each patch release of OCDS, and provides a worked example of how core extension versioning should work. 