### PR TITLE
Add note on running standard maintenance scripts tests

### DIFF
--- a/docs/standard/technical/build.rst
+++ b/docs/standard/technical/build.rst
@@ -55,6 +55,8 @@ The standard's tests must be run after building the documentation:
    make
    py.test
 
+To replicate the Github Actions workfow, you also need to [run the tests from the standard maintenance scripts](https://github.com/open-contracting/standard-maintenance-scripts#tests).
+
 Build the documentation
 -----------------------
 

--- a/docs/standard/technical/build.rst
+++ b/docs/standard/technical/build.rst
@@ -55,7 +55,7 @@ The standard's tests must be run after building the documentation:
    make
    py.test
 
-To replicate the Github Actions workfow, you also need to [run the tests from the standard maintenance scripts](https://github.com/open-contracting/standard-maintenance-scripts#tests).
+To replicate the Github Actions workfow, you also need to `run the tests from the standard maintenance scripts <https://github.com/open-contracting/standard-maintenance-scripts#tests>`__.
 
 Build the documentation
 -----------------------


### PR DESCRIPTION
If I understood https://github.com/open-contracting/standard/pull/1123#issuecomment-734394089 correctly, we also need to do this to run all the tests locally.