### PR TITLE
style guide: prefer 'hyphen' to 'dash'

### DIFF
--- a/docs/meta/style_guide.rst
+++ b/docs/meta/style_guide.rst
@@ -40,6 +40,7 @@ Word choice
 -  "changelog" not "change-log" or "change log"
 -  "data package" not "datapackage"
 -  "metadata" not "meta-data" or "meta data"
+-  to describe the "-" character, "hyphen" not "dash" 
 
 When describing JSON Schema:
 


### PR DESCRIPTION
From https://github.com/open-contracting/standard/issues/834#issuecomment-861659915