### PR TITLE
build.rst: Add instructions for installing Chrome

### DIFF
--- a/docs/standard/technical/build.rst
+++ b/docs/standard/technical/build.rst
@@ -48,6 +48,13 @@ Run tests
 
 .. admonition:: One-time setup
 
+   Install Chrome. On Linux:
+
+   .. code-block:: shell
+
+      curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+      sudo apt install ./google-chrome-stable_current_amd64.deb
+   
    Install ChromeDriver. On Linux:
 
    .. code-block:: shell


### PR DESCRIPTION
Chrome is required by Chromedriver so we should mention that somewhere on the build page.

Edit: I'm not familiar with MacOS so I've just added the Linux instructions.