### PR TITLE
docs/meta/schema_style_guide.rst: Update description field guidance

### DIFF
--- a/docs/meta/schema_style_guide.rst
+++ b/docs/meta/schema_style_guide.rst
@@ -305,7 +305,7 @@ For the ``description`` field of an object:
 ..
 
    A short description of the document. Descriptions are recommended to not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document.
-   
+
 Documents
 ~~~~~~~~~
 

--- a/docs/meta/schema_style_guide.rst
+++ b/docs/meta/schema_style_guide.rst
@@ -296,16 +296,16 @@ For the ``description`` field of an object:
 
 .. code-block:: none
 
-   A description of this <object_name>. Structured information should be provided in <related_fields>.
+   A description of this <object_name>.
 
 **Examples:**
 
-   A description of this tender. Structured information should be provided in the items array. Descriptions should be short and easy to read. Avoid using ALL CAPS.
+   A summary description of the tender. This complements any structured information provided using the items array. Descriptions should be short and easy to read. Avoid using ALL CAPS.
 
 ..
 
-   A description of this document. Descriptions should not exceed 250 words. In the event the document is not accessible online, the description field may be used to describe arrangements for obtaining a copy of the document.
-
+   A short description of the document. Descriptions are recommended to not exceed 250 words. In the event the document is not accessible online, the description field can be used to describe arrangements for obtaining a copy of the document.
+   
 Documents
 ~~~~~~~~~
 


### PR DESCRIPTION
From https://github.com/open-contracting-extensions/ocds_sustainability_extension/pull/3#discussion_r1165838156

I also updated the examples with the field descriptions from the `1.2-dev` branch.