### PR TITLE
schema_style_guide.rst: add guidance for authoring titles

### DIFF
--- a/docs/meta/schema_style_guide.rst
+++ b/docs/meta/schema_style_guide.rst
@@ -319,7 +319,7 @@ Codelists
 
 .. code-block:: none
 
-   <semantics>, using the <open/closed> <name> codelist. See also the <xDetails> field.
+   <semantics>, using the <open/closed> <name> codelist.
 
 **Example:**
 

--- a/docs/meta/schema_style_guide.rst
+++ b/docs/meta/schema_style_guide.rst
@@ -246,6 +246,12 @@ Field and code names
 
    Until OCDS 2.0, publishers must use the ``tender`` term, and not choose their own terms, in order to maintain interoperability. The choice of a term is cosmetic; it's not semantic. A field's description, not its name, is semantic.
 
+Field and code titles
+---------------------
+
+- Use `sentence case <https://en.wikipedia.org/wiki/Letter_case#Sentence_case>`__.
+- Field titles should not include their parent's title, e.g. ``Title`` not ``Tender title``, ``Description`` not ``Award description``, etc.
+
 Field and code descriptions
 ---------------------------
 


### PR DESCRIPTION
closes #280 

also removed the line "See also the <xDetails> field." for the codelists guidance as per [comment in H36](https://docs.google.com/spreadsheets/d/1WaN5cdU5UxoCMkq8Od5zlLj68-ckn1lnzWpt_DfzqHk/edit#gid=0)