### PR TITLE
Describe what not to translate

### DIFF
--- a/docs/standard/translation/using_transifex.rst
+++ b/docs/standard/translation/using_transifex.rst
@@ -16,7 +16,7 @@ Translator
 #. Sort by "Untranslated (Descending)"
 #. Click on a resource with untranslated strings
 #. Click "Untranslated"
-#. Read the English text and author the translated text
+#. Read the English text and author the translated text. Do not translate words in backticks (e.g. \`title\`) or single quotes (e.g. 'open').
 #. Click "Save Translation" (or press ``TAB``)
 #. Repeat from Step 4
 #. Notify the Proofreader when strings have been translated

--- a/docs/standard/translation/using_transifex.rst
+++ b/docs/standard/translation/using_transifex.rst
@@ -16,7 +16,7 @@ Translator
 #. Sort by "Untranslated (Descending)"
 #. Click on a resource with untranslated strings
 #. Click "Untranslated"
-#. Read the English text and author the translated text. Do not translate words in backticks (e.g. \`title\`) or single quotes (e.g. 'open').
+#. Read the English text and author the translated text. Do not translate words in backticks, e.g. \`title\`, or single quotes, e.g. 'open'. When translating a hyperlink, do not translate the part in parentheses (round brackets), e.g. [translate this text](#do-not-translate-this-text).
 #. Click "Save Translation" (or press ``TAB``)
 #. Repeat from Step 4
 #. Notify the Proofreader when strings have been translated

--- a/docs/standard/translation/using_transifex.rst
+++ b/docs/standard/translation/using_transifex.rst
@@ -16,7 +16,18 @@ Translator
 #. Sort by "Untranslated (Descending)"
 #. Click on a resource with untranslated strings
 #. Click "Untranslated"
-#. Read the English text and author the translated text. Do not translate words in backticks, e.g. \`title\`, or single quotes, e.g. 'open'. When translating a hyperlink, do not translate the part in parentheses (round brackets), e.g. [translate this text](#do-not-translate-this-text).
+#. Read the English text and author the translated text
+
+   .. warning::
+
+      Do not translate:
+
+      -  words in backticks, like \`title\` (often used for schema fields)
+      -  words in single quotes, like 'open' (often used for codelist codes)
+      -  relative URLs, like ``[translate this](#but-not-this)``
+
+      Absolute URLs (that is, starting with ``https://``) can be translated: for example, if the website offers content in multiple languages.
+
 #. Click "Save Translation" (or press ``TAB``)
 #. Repeat from Step 4
 #. Notify the Proofreader when strings have been translated


### PR DESCRIPTION
I forgot to add this in #288

Regarding my question in https://github.com/open-contracting/infrastructure/issues/467#issuecomment-1969942902:

>  Likewise, we should explain what to do with relative URLs, e.g. if a heading in the schema reference Markdown page is translated, should the translator update the references to that heading, or is that something that we do afterwards as part of a tidy-up?

I realised that the anchor slugs created by the MyST parser are not translated, e.g. https://standard.open-contracting.org/infrastructure/latest/es/guidance/identifiers/#project-identifiers-in-ocds